### PR TITLE
Extract timeline from expenses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
+    testImplementation 'org.hamcrest:hamcrest:2.1'
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -59,7 +59,6 @@
             value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
         <property name="specialImportsRegExp" value="^org\."/>
         <property name="thirdPartyPackageRegExp" value="^com\."/>
-        <property name="sortImportsInGroupAlphabetically" value="true"/>
     </module>
 
     <!-- Checks for redundant import statements.

--- a/src/main/java/seedu/billboard/commons/core/date/DateInterval.java
+++ b/src/main/java/seedu/billboard/commons/core/date/DateInterval.java
@@ -1,0 +1,42 @@
+package seedu.billboard.commons.core.date;
+
+import java.time.DayOfWeek;
+import java.time.Period;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAdjusters;
+
+
+/**
+ * Enum representing an interval for dates.
+ */
+public enum DateInterval {
+    DAY(Period.ofDays(1), TemporalAdjusters.ofDateAdjuster(x -> x)),
+    WEEK(Period.ofWeeks(1), TemporalAdjusters.previous(DayOfWeek.MONDAY)),
+    MONTH(Period.ofMonths(1), TemporalAdjusters.firstDayOfMonth()),
+    YEAR(Period.ofYears(1), TemporalAdjusters.firstDayOfYear());
+
+    private final Period period;
+    private final TemporalAdjuster adjuster;
+
+    DateInterval(Period period, TemporalAdjuster adjuster) {
+        this.period = period;
+        this.adjuster = adjuster;
+    }
+
+    /**
+     * Getter for the time period this interval represents.
+     * @return the time period, as a {@code Period}.
+     */
+    public Period getPeriod() {
+        return period;
+    }
+
+    /**
+     * Getter for the {@code TemporalAdjuster} to get the previous date from a {@code LocalDate} that represents the
+     * start of a logical human period, such as the previous Monday, or the first day of a month.
+     * @return the appropriate {@code TemporalAdjuster}.
+     */
+    public TemporalAdjuster getAdjuster() {
+        return adjuster;
+    }
+}

--- a/src/main/java/seedu/billboard/commons/core/date/DateRange.java
+++ b/src/main/java/seedu/billboard/commons/core/date/DateRange.java
@@ -1,0 +1,95 @@
+package seedu.billboard.commons.core.date;
+
+import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.billboard.commons.exceptions.IllegalValueException;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * Represents a immutable {@code DateRange} from {@code startDate} to {@code endDate}.
+ */
+public class DateRange {
+
+    private static final String INVALID_DATES_MESSAGE = "End date should not be before start date!";
+
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    /**
+     * Creates a new date range starting from {@code startDate} to {@code endDate}.
+     * @param startDate The starting date.
+     * @param endDate The ending date.
+     */
+    public DateRange(LocalDate startDate, LocalDate endDate) throws IllegalValueException {
+        requireAllNonNull(startDate, endDate);
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalValueException(INVALID_DATES_MESSAGE);
+        }
+
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    /**
+     * Getter for start date.
+     * @return Start date, as a {@code LocalDate}.
+     */
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Getter for end date.
+     * @return End date, as a {@code LocalDate}.
+     */
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Creates a list of new ranges by splitting the current {@code DateRange} into smaller ranges based on the given
+     * interval. The ranges returned are sequential, and the first range starts at the previous human logical start
+     * date for the given interval. For example, if {@code DateInterval.MONTH} is passed in, the first date range will
+     * start on the first day of the month.
+     * If the date range cannot be divided evenly into the smaller intervals, the final element of the list will
+     * contain the {@code endDate} in its date range, ie. it is end inclusive.
+     *
+     * @param interval Specified interval to divide the date range by.
+     * @return List of date ranges that span the same duration as the given intervals, from the start date to end date,
+     *         possible exceeding the end date.
+     */
+    public List<DateRange> partitionByInterval(DateInterval interval) {
+        LocalDate closestStart = startDate.with(interval.getAdjuster());
+
+        return closestStart.datesUntil(endDate, interval.getPeriod())
+                .map(start -> dateRangeOverPeriod(start, interval.getPeriod()))
+                .collect(Collectors.toList());
+    }
+
+    private DateRange dateRangeOverPeriod(LocalDate startDate, Period period) {
+        try {
+            return new DateRange(startDate, startDate.plus(period).minus(Period.ofDays(1)));
+        } catch (IllegalValueException e) {
+            // should never happen
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true; // short circuit if same object
+        } else if (obj instanceof DateRange) {
+            DateRange other = (DateRange) obj;
+            return startDate.equals(other.startDate) && endDate.equals(other.endDate);
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/seedu/billboard/commons/core/date/DateRange.java
+++ b/src/main/java/seedu/billboard/commons/core/date/DateRange.java
@@ -2,13 +2,13 @@ package seedu.billboard.commons.core.date;
 
 import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
 
-import seedu.billboard.commons.exceptions.IllegalValueException;
-
 import java.time.LocalDate;
 import java.time.Period;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+
+import seedu.billboard.commons.exceptions.IllegalValueException;
 
 
 /**
@@ -72,6 +72,12 @@ public class DateRange {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Creates a date range starting at the given start date, and lasting for as long as the given period.
+     * @param startDate Given start date.
+     * @param period Period the date range should last for.
+     * @return the newly created date range.
+     */
     private DateRange dateRangeOverPeriod(LocalDate startDate, Period period) {
         try {
             return new DateRange(startDate, startDate.plus(period).minus(Period.ofDays(1)));
@@ -79,6 +85,12 @@ public class DateRange {
             // should never happen
             return null;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(startDate, endDate);
     }
 
     @Override

--- a/src/main/java/seedu/billboard/commons/core/date/DateRange.java
+++ b/src/main/java/seedu/billboard/commons/core/date/DateRange.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import seedu.billboard.commons.exceptions.IllegalValueException;
-
 
 /**
  * Represents a immutable {@code DateRange} from {@code startDate} to {@code endDate}.
@@ -23,13 +21,15 @@ public class DateRange {
 
     /**
      * Creates a new date range starting from {@code startDate} to {@code endDate}.
+     *
      * @param startDate The starting date.
-     * @param endDate The ending date.
+     * @param endDate   The ending date.
+     * @throws IllegalArgumentException if the end date is before the start date.
      */
-    public DateRange(LocalDate startDate, LocalDate endDate) throws IllegalValueException {
+    public DateRange(LocalDate startDate, LocalDate endDate) throws IllegalArgumentException {
         requireAllNonNull(startDate, endDate);
         if (endDate.isBefore(startDate)) {
-            throw new IllegalValueException(INVALID_DATES_MESSAGE);
+            throw new IllegalArgumentException(INVALID_DATES_MESSAGE);
         }
 
         this.startDate = startDate;
@@ -37,7 +37,19 @@ public class DateRange {
     }
 
     /**
+     * Creates a date range starting at the given start date, and lasting for as long as the given period.
+     *
+     * @param startDate Given start date.
+     * @param period    Period the date range should last for.
+     * @return the newly created date range.
+     */
+    public static DateRange overPeriod(LocalDate startDate, Period period) {
+        return new DateRange(startDate, startDate.plus(period).minus(Period.ofDays(1)));
+    }
+
+    /**
      * Getter for start date.
+     *
      * @return Start date, as a {@code LocalDate}.
      */
     public LocalDate getStartDate() {
@@ -46,10 +58,20 @@ public class DateRange {
 
     /**
      * Getter for end date.
+     *
      * @return End date, as a {@code LocalDate}.
      */
     public LocalDate getEndDate() {
         return endDate;
+    }
+
+    /**
+     * Checks if the given date lies within this {@code DateRange}
+     * @param date Date to be checked.
+     * @return true if the date lies within the date range, false otherwise.
+     */
+    public boolean contains(LocalDate date) {
+        return !date.isBefore(startDate) && !date.isAfter(endDate);
     }
 
     /**
@@ -62,29 +84,14 @@ public class DateRange {
      *
      * @param interval Specified interval to divide the date range by.
      * @return List of date ranges that span the same duration as the given intervals, from the start date to end date,
-     *         possible exceeding the end date.
+     * possible exceeding the end date.
      */
     public List<DateRange> partitionByInterval(DateInterval interval) {
         LocalDate closestStart = startDate.with(interval.getAdjuster());
 
         return closestStart.datesUntil(endDate, interval.getPeriod())
-                .map(start -> dateRangeOverPeriod(start, interval.getPeriod()))
+                .map(start -> overPeriod(start, interval.getPeriod()))
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Creates a date range starting at the given start date, and lasting for as long as the given period.
-     * @param startDate Given start date.
-     * @param period Period the date range should last for.
-     * @return the newly created date range.
-     */
-    private DateRange dateRangeOverPeriod(LocalDate startDate, Period period) {
-        try {
-            return new DateRange(startDate, startDate.plus(period).minus(Period.ofDays(1)));
-        } catch (IllegalValueException e) {
-            // should never happen
-            return null;
-        }
     }
 
     @Override

--- a/src/main/java/seedu/billboard/commons/core/date/DateRange.java
+++ b/src/main/java/seedu/billboard/commons/core/date/DateRange.java
@@ -10,11 +10,11 @@ import java.util.stream.Collectors;
 
 
 /**
- * Represents a immutable {@code DateRange} from {@code startDate} to {@code endDate}.
+ * Represents a immutable {@code DateRange} from {@code startDate} to {@code endDate} inclusive.
  */
 public class DateRange {
 
-    private static final String INVALID_DATES_MESSAGE = "End date should not be before start date!";
+    private static final String INVALID_DATES_MESSAGE = "End date should not be before start date.";
 
     private final LocalDate startDate;
     private final LocalDate endDate;
@@ -37,13 +37,18 @@ public class DateRange {
     }
 
     /**
-     * Creates a date range starting at the given start date, and lasting for as long as the given period.
+     * Creates a date range starting at the given start date, and lasts for as long as the given period. Only accepts
+     * positive {@code Period} values. Zero or negative {@code Period} values will throw an exception.
      *
      * @param startDate Given start date.
      * @param period    Period the date range should last for.
      * @return the newly created date range.
+     * @throws IllegalArgumentException if the period given is negative or zero.
      */
-    public static DateRange overPeriod(LocalDate startDate, Period period) {
+    public static DateRange overPeriod(LocalDate startDate, Period period) throws IllegalArgumentException {
+        if (period.isZero() || period.isNegative()) {
+            throw new IllegalArgumentException("Period cannot be negative or zero.");
+        }
         return new DateRange(startDate, startDate.plus(period).minus(Period.ofDays(1)));
     }
 
@@ -110,5 +115,10 @@ public class DateRange {
         }
 
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return "start: " + startDate.toString() + "\nEnd: " + endDate.toString();
     }
 }

--- a/src/main/java/seedu/billboard/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/billboard/commons/util/CollectionUtil.java
@@ -27,6 +27,14 @@ public class CollectionUtil {
     }
 
     /**
+     * Returns true if and only if {@code items} is non empty.
+     */
+    public static boolean checkNonEmpty(Collection<?> items) {
+        requireNonNull(items);
+        return items.size() != 0;
+    }
+
+    /**
      * Returns true if {@code items} contain any elements that are non-null.
      */
     public static boolean isAnyNonNull(Object... items) {

--- a/src/main/java/seedu/billboard/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/billboard/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.billboard.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_TAG;
@@ -22,11 +23,13 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "NAME"
             + PREFIX_DESCRIPTION + "DESCRIPTION "
             + PREFIX_AMOUNT + "AMOUNT "
+            + PREFIX_DATE + "DATE"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Bought "
             + PREFIX_DESCRIPTION + "Buy a book "
             + PREFIX_AMOUNT + "9.00" + " "
+            + PREFIX_DATE + "25/3/2019 1200"
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/billboard/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/billboard/logic/commands/AddTagCommand.java
@@ -58,7 +58,7 @@ public class AddTagCommand extends TagCommand {
         Set<Tag> toAdd = model.retrieveTags(tagNames);
         Set<Tag> mergedSet = getUniqueSet(currTags, toAdd);
         Expense editedExpense = new Expense(expenseToEdit.getName(), expenseToEdit.getDescription(),
-                expenseToEdit.getAmount(), mergedSet);
+                expenseToEdit.getAmount(), expenseToEdit.getCreated(), mergedSet);
 
         model.setExpense(expenseToEdit, editedExpense);
         model.updateFilteredExpenses(PREDICATE_SHOW_ALL_EXPENSES);

--- a/src/main/java/seedu/billboard/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/billboard/logic/commands/EditCommand.java
@@ -19,6 +19,7 @@ import seedu.billboard.commons.util.CollectionUtil;
 import seedu.billboard.logic.commands.exceptions.CommandException;
 import seedu.billboard.model.Model;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
@@ -91,11 +92,12 @@ public class EditCommand extends Command {
      */
     private static Expense createEditedExpense(Expense expenseToEdit, EditExpenseDescriptor editExpenseDescriptor) {
         assert expenseToEdit != null;
-        Set<Tag> updatedTags = editExpenseDescriptor.getTags().orElse(expenseToEdit.getTags());
         Name updatedName = editExpenseDescriptor.getName().orElse(expenseToEdit.getName());
         Description updatedDescription = editExpenseDescriptor.getDescription().orElse(expenseToEdit.getDescription());
         Amount updatedAmount = editExpenseDescriptor.getAmount().orElse(expenseToEdit.getAmount());
-        return new Expense(updatedName, updatedDescription, updatedAmount, updatedTags);
+        CreatedDateTime updatedCreated = editExpenseDescriptor.getCreated().orElse(expenseToEdit.getCreated());
+        Set<Tag> updatedTags = editExpenseDescriptor.getTags().orElse(expenseToEdit.getTags());
+        return new Expense(updatedName, updatedDescription, updatedAmount, updatedCreated, updatedTags);
     }
 
     @Override
@@ -123,9 +125,10 @@ public class EditCommand extends Command {
     public static class EditExpenseDescriptor {
 
         private Name name;
-        private Set<Tag> tags;
         private Description description;
         private Amount amount;
+        private CreatedDateTime created;
+        private Set<Tag> tags;
 
         public EditExpenseDescriptor() {
         }
@@ -136,9 +139,10 @@ public class EditCommand extends Command {
          */
         public EditExpenseDescriptor(EditExpenseDescriptor toCopy) {
             setName(toCopy.name);
-            setTags(toCopy.tags);
             setDescription(toCopy.description);
+            setCreated(toCopy.created);
             setAmount(toCopy.amount);
+            setTags(toCopy.tags);
         }
 
         /**
@@ -171,6 +175,14 @@ public class EditCommand extends Command {
 
         public Optional<Amount> getAmount() {
             return Optional.ofNullable(amount);
+        }
+
+        public void setCreated(CreatedDateTime created) {
+            this.created = created;
+        }
+
+        public Optional<CreatedDateTime> getCreated() {
+            return Optional.ofNullable(created);
         }
 
         /**

--- a/src/main/java/seedu/billboard/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/billboard/logic/commands/EditCommand.java
@@ -2,6 +2,7 @@ package seedu.billboard.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_TAG;
@@ -39,6 +40,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
             + "[" + PREFIX_AMOUNT + "AMOUNT] "
+            + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_DESCRIPTION + "buy tea "
@@ -75,9 +77,7 @@ public class EditCommand extends Command {
         Expense expenseToEdit = lastShownList.get(index.getZeroBased());
         Expense editedExpense = createEditedExpense(expenseToEdit, editExpenseDescriptor);
 
-        boolean b = !expenseToEdit.equals(editedExpense);
-        boolean b1 = model.hasExpense(editedExpense);
-        if (b && b1) {
+        if (!expenseToEdit.equals(editedExpense) && model.hasExpense(editedExpense)) {
             throw new CommandException(MESSAGE_DUPLICATE_EXPENSE);
         }
 
@@ -149,7 +149,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, description, amount, tags);
+            return CollectionUtil.isAnyNonNull(name, description, amount, created, tags);
         }
 
 

--- a/src/main/java/seedu/billboard/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/billboard/logic/parser/AddCommandParser.java
@@ -29,6 +29,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     *
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =

--- a/src/main/java/seedu/billboard/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/billboard/logic/parser/AddCommandParser.java
@@ -2,16 +2,19 @@ package seedu.billboard.logic.parser;
 
 import static seedu.billboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.billboard.logic.commands.AddCommand;
 import seedu.billboard.logic.parser.exceptions.ParseException;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
@@ -29,7 +32,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_AMOUNT, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION,
+                        PREFIX_AMOUNT, PREFIX_DATE, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_AMOUNT)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -39,9 +43,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse(" "));
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
+        CreatedDateTime createdDateTime = argMultimap.getValue(PREFIX_DATE).isPresent()
+                ? ParserUtil.parseCreatedDateTime(argMultimap.getValue(PREFIX_DATE).get())
+                : new CreatedDateTime(LocalDateTime.now());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Expense expense = new Expense(name, description, amount, tagList);
+        Expense expense = new Expense(name, description, amount, createdDateTime, tagList);
 
         return new AddCommand(expense);
     }

--- a/src/main/java/seedu/billboard/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/billboard/logic/parser/CliSyntax.java
@@ -9,5 +9,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
+    public static final Prefix PREFIX_DATE = new Prefix("date/");
     public static final Prefix PREFIX_AMOUNT = new Prefix("a/");
 }

--- a/src/main/java/seedu/billboard/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/billboard/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.billboard.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.billboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_TAG;
@@ -31,7 +32,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_AMOUNT, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION,
+                        PREFIX_AMOUNT, PREFIX_DATE, PREFIX_TAG);
 
         Index index;
 
@@ -51,9 +53,16 @@ public class EditCommandParser implements Parser<EditCommand> {
             editExpenseDescriptor.setDescription(ParserUtil
                     .parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get()));
         }
+
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             editExpenseDescriptor.setAmount(ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get()));
         }
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            editExpenseDescriptor.setCreated(
+                    ParserUtil.parseCreatedDateTime(argMultimap.getValue(PREFIX_DATE).get()));
+        }
+
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editExpenseDescriptor::setTags);
 
         if (!editExpenseDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/billboard/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/billboard/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import seedu.billboard.commons.core.index.Index;
 import seedu.billboard.commons.util.StringUtil;
 import seedu.billboard.logic.parser.exceptions.ParseException;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Name;
 import seedu.billboard.model.tag.Tag;
@@ -134,5 +135,20 @@ public class ParserUtil {
             throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
         }
         return new Amount(trimmedAmount);
+    }
+
+    /**
+     * Parses a {@code String dateTime} into an {@code CreatedDateTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code dateTime} is invalid.
+     */
+    public static CreatedDateTime parseCreatedDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+        if (!CreatedDateTime.isValidDate(trimmedDateTime)) {
+            throw new ParseException(CreatedDateTime.MESSAGE_CONSTRAINTS);
+        }
+        return new CreatedDateTime(trimmedDateTime);
     }
 }

--- a/src/main/java/seedu/billboard/model/ModelManager.java
+++ b/src/main/java/seedu/billboard/model/ModelManager.java
@@ -157,4 +157,9 @@ public class ModelManager implements Model {
                 && filteredExpense.equals(other.filteredExpense);
     }
 
+    @Override
+    public String toString() {
+        return "b: " + billboard.toString() + "up: " + userPrefs.toString() + "fe: " + filteredExpense.toString();
+    }
+    //TODO REmove
 }

--- a/src/main/java/seedu/billboard/model/ModelManager.java
+++ b/src/main/java/seedu/billboard/model/ModelManager.java
@@ -38,6 +38,7 @@ public class ModelManager implements Model {
         this.billboard = new Billboard(billboard);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredExpense = new FilteredList<>(this.billboard.getExpenses());
+
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/billboard/model/expense/Address.java
+++ b/src/main/java/seedu/billboard/model/expense/Address.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.billboard.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Expense's address in the address book.
+ * Represents a Expense's address in the Billboard.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
 public class Address {

--- a/src/main/java/seedu/billboard/model/expense/Amount.java
+++ b/src/main/java/seedu/billboard/model/expense/Amount.java
@@ -29,6 +29,15 @@ public class Amount {
         }
     }
 
+    /**
+     * Adds this amount to another amount.
+     * @param other Amount to be added.
+     * @return new Amount representing the combine total of the two amounts.
+     */
+    public Amount add(Amount other) {
+        return new Amount((amount + other.amount) + "");
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
+++ b/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
@@ -74,7 +74,7 @@ public class CreatedDateTime {
         try {
             tryParse(test);
             return true;
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | DateTimeParseException e) {
             return false;
         }
     }

--- a/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
+++ b/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
@@ -17,12 +17,12 @@ import java.util.stream.Collectors;
 public class CreatedDateTime {
 
     // More formats can be added
-    private static final List<String> acceptablePatterns =
-            List.of("d/M/yyyy HHmm", "d/M/yyyy");
-    private static final DateTimeFormatter outputFormat = DateTimeFormatter.ofPattern("dd MMM yyyy, hh:kk a");
+    public static final List<String> ACCEPTABLE_PATTERNS = List.of("d/M/yyyy[ HHmm]");
 
     public static final String MESSAGE_CONSTRAINTS = "Created date should follow one of these formats:\n"
-             + String.join("\n", acceptablePatterns);
+             + String.join("\n", ACCEPTABLE_PATTERNS);
+
+    private static final DateTimeFormatter outputFormat = DateTimeFormatter.ofPattern("dd MMM yyyy, hh:kk a");
 
 
     public final LocalDateTime dateTime;
@@ -47,7 +47,7 @@ public class CreatedDateTime {
      * @throws IllegalArgumentException if the date string does not match the accepted formats.
      */
     private static LocalDateTime tryParse(String dateString) throws IllegalArgumentException {
-        List<DateTimeFormatter> acceptableFormats = acceptablePatterns.stream()
+        List<DateTimeFormatter> acceptableFormats = ACCEPTABLE_PATTERNS.stream()
                 .map(DateTimeFormatter::ofPattern)
                 .collect(Collectors.toList());
 
@@ -59,7 +59,6 @@ public class CreatedDateTime {
                 } else if (accessor instanceof LocalDate) {
                     return ((LocalDate) accessor).atStartOfDay();
                 }
-
             } catch (DateTimeParseException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
+++ b/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
@@ -1,0 +1,88 @@
+package seedu.billboard.model.expense;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a Expense's created dateTime in the Billboard.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
+ */
+public class CreatedDateTime {
+
+    // More formats can be added
+    private static final List<String> acceptablePatterns =
+            List.of("d/M/yyyy HHmm", "d/M/yyyy", "dd MMM yyyy, hh:kk a");
+    private static final DateTimeFormatter outputFormat = DateTimeFormatter.ofPattern("dd MMM yyyy, hh:kk a");
+
+    public static final String MESSAGE_CONSTRAINTS = "Created date should follow one of these formats:\n"
+             + String.join("\n", acceptablePatterns);
+
+
+    public final LocalDateTime dateTime;
+
+    public CreatedDateTime(String dateString) {
+        requireNonNull(dateString);
+        dateTime = tryParse(dateString);
+    }
+
+    /**
+     *  Convenience constructor to create the date time directly from a {@code LocalDateTime}.
+     */
+    public CreatedDateTime(LocalDateTime dateTime) {
+        requireNonNull(dateTime);
+        this.dateTime = dateTime;
+    }
+
+    private static LocalDateTime tryParse(String dateString) throws IllegalArgumentException {
+        List<DateTimeFormatter> acceptableFormats = acceptablePatterns.stream()
+                .map(DateTimeFormatter::ofPattern)
+                .collect(Collectors.toList());
+
+        for (DateTimeFormatter formatter : acceptableFormats) {
+            try {
+                TemporalAccessor accessor =  formatter.parseBest(dateString, LocalDateTime::from, LocalDate::from);
+                if (accessor instanceof LocalDateTime) {
+                    return (LocalDateTime) accessor;
+                } else if (accessor instanceof LocalDate) {
+                    return ((LocalDate) accessor).atStartOfDay();
+                }
+
+            } catch (DateTimeParseException e) {
+                e.printStackTrace();
+            }
+        }
+
+        throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
+    }
+
+    /**
+     * Returns true if the given string is a valid date under the acceptable formats.
+     */
+    public static boolean isValidDate(String test) {
+        try {
+            tryParse(test);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CreatedDateTime // instanceof handles nulls
+                && dateTime.equals(((CreatedDateTime) other).dateTime)); // state check
+    }
+
+    @Override
+    public String toString() {
+        return dateTime.format(outputFormat);
+    }
+}

--- a/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
+++ b/src/main/java/seedu/billboard/model/expense/CreatedDateTime.java
@@ -18,7 +18,7 @@ public class CreatedDateTime {
 
     // More formats can be added
     private static final List<String> acceptablePatterns =
-            List.of("d/M/yyyy HHmm", "d/M/yyyy", "dd MMM yyyy, hh:kk a");
+            List.of("d/M/yyyy HHmm", "d/M/yyyy");
     private static final DateTimeFormatter outputFormat = DateTimeFormatter.ofPattern("dd MMM yyyy, hh:kk a");
 
     public static final String MESSAGE_CONSTRAINTS = "Created date should follow one of these formats:\n"
@@ -40,6 +40,12 @@ public class CreatedDateTime {
         this.dateTime = dateTime;
     }
 
+    /**
+     * Attempts to parse the given date string based on the acceptable formats.
+     * @param dateString Input date string
+     * @return The parsed LocalDateTime, if successful.
+     * @throws IllegalArgumentException if the date string does not match the accepted formats.
+     */
     private static LocalDateTime tryParse(String dateString) throws IllegalArgumentException {
         List<DateTimeFormatter> acceptableFormats = acceptablePatterns.stream()
                 .map(DateTimeFormatter::ofPattern)
@@ -47,7 +53,7 @@ public class CreatedDateTime {
 
         for (DateTimeFormatter formatter : acceptableFormats) {
             try {
-                TemporalAccessor accessor =  formatter.parseBest(dateString, LocalDateTime::from, LocalDate::from);
+                TemporalAccessor accessor = formatter.parseBest(dateString, LocalDateTime::from, LocalDate::from);
                 if (accessor instanceof LocalDateTime) {
                     return (LocalDateTime) accessor;
                 } else if (accessor instanceof LocalDate) {

--- a/src/main/java/seedu/billboard/model/expense/Expense.java
+++ b/src/main/java/seedu/billboard/model/expense/Expense.java
@@ -77,13 +77,14 @@ public class Expense {
         return otherExpense.getName().equals(getName())
                 && otherExpense.getDescription().equals(getDescription())
                 && otherExpense.getAmount().equals(getAmount())
+                && otherExpense.getCreated().equals(getCreated())
                 && otherExpense.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, description, amount);
+        return Objects.hash(name, description, amount, created, tags);
     }
 
     @Override
@@ -93,6 +94,10 @@ public class Expense {
                 + " Description: "
                 + getDescription()
                 + " Amount: "
-                + getAmount();
+                + getAmount()
+                + " Created: "
+                + getCreated()
+                + " Tags: "
+                + getTags();
     }
 }

--- a/src/main/java/seedu/billboard/model/expense/Expense.java
+++ b/src/main/java/seedu/billboard/model/expense/Expense.java
@@ -2,7 +2,6 @@ package seedu.billboard.model.expense;
 
 import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;

--- a/src/main/java/seedu/billboard/model/expense/Expense.java
+++ b/src/main/java/seedu/billboard/model/expense/Expense.java
@@ -28,7 +28,10 @@ public class Expense {
     /**
      * Every field must be present and not null.
      */
-    public Expense(Name name, Description description, Amount amount, CreatedDateTime created, Set<Tag> tags) {
+    public Expense(Name name, Description description,
+                   Amount amount, CreatedDateTime created,
+                   Set<Tag> tags) {
+
         requireAllNonNull(name, description, created, amount, tags);
         this.name = name;
         this.description = description;
@@ -38,11 +41,15 @@ public class Expense {
         this.archiveName = "";
     }
 
-    public Expense(Name name, Description description, Amount amount, Set<Tag> tags, String archiveName) {
+    public Expense(Name name, Description description,
+                   Amount amount, CreatedDateTime created,
+                   Set<Tag> tags, String archiveName) {
+
         requireAllNonNull(name, description, amount);
         this.name = name;
         this.description = description;
         this.amount = amount;
+        this.created = created;
         this.tags.addAll(tags);
         this.archiveName = archiveName;
     }

--- a/src/main/java/seedu/billboard/model/expense/Expense.java
+++ b/src/main/java/seedu/billboard/model/expense/Expense.java
@@ -2,6 +2,7 @@ package seedu.billboard.model.expense;
 
 import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -19,17 +20,19 @@ public class Expense {
     private Name name;
     private Description description;
     private Amount amount;
+    private CreatedDateTime created;
 
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
     /**
      * Every field must be present and not null.
      */
-    public Expense(Name name, Description description, Amount amount, Set<Tag> tags) {
-        requireAllNonNull(name, description, amount);
+    public Expense(Name name, Description description, Amount amount, CreatedDateTime created, Set<Tag> tags) {
+        requireAllNonNull(name, description, created, amount, tags);
         this.name = name;
         this.description = description;
         this.amount = amount;
+        this.created = created;
         this.tags.addAll(tags);
     }
 
@@ -43,6 +46,10 @@ public class Expense {
 
     public Amount getAmount() {
         return amount;
+    }
+
+    public CreatedDateTime getCreated() {
+        return created;
     }
 
     /**

--- a/src/main/java/seedu/billboard/model/expense/Name.java
+++ b/src/main/java/seedu/billboard/model/expense/Name.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.billboard.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Expense's name in the address book.
+ * Represents a Expense's name in the Billboard.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {

--- a/src/main/java/seedu/billboard/model/statistics/EmptyExpenseTimeline.java
+++ b/src/main/java/seedu/billboard/model/statistics/EmptyExpenseTimeline.java
@@ -1,0 +1,44 @@
+package seedu.billboard.model.statistics;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.Map;
+
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.commons.core.date.DateRange;
+import seedu.billboard.model.expense.Amount;
+
+/**
+ * Class representing an {@code ExpenseTimeline} with no expenses to show.
+ */
+public class EmptyExpenseTimeline implements ExpenseTimeline {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    public EmptyExpenseTimeline() {
+        endDate = LocalDate.now();
+        startDate = endDate.minus(Period.ofMonths(1));
+    }
+
+    @Override
+    public DateRange getDateRange() {
+        return new DateRange(startDate, endDate);
+    }
+
+    @Override
+    public DateInterval getDateInterval() {
+        return DateInterval.MONTH;
+    }
+
+    @Override
+    public List<Amount> getTotalAmounts() {
+        return List.of(new Amount("0"));
+    }
+
+    @Override
+    public Map<DateRange, Amount> getTimeline() {
+        return Map.of(new DateRange(startDate, endDate), new Amount("0"));
+    }
+}

--- a/src/main/java/seedu/billboard/model/statistics/ExpenseTimeline.java
+++ b/src/main/java/seedu/billboard/model/statistics/ExpenseTimeline.java
@@ -1,0 +1,82 @@
+package seedu.billboard.model.statistics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.commons.core.date.DateRange;
+import seedu.billboard.commons.exceptions.IllegalValueException;
+import seedu.billboard.model.expense.Amount;
+
+/**
+ * Represents the aggregate expenses for every interval of time, over a specified range of time
+ */
+public class ExpenseTimeline {
+
+    private static final String INVALID_PARAMETERS_MESSAGE = "Number of aggregate expenses and number of date "
+            + "intervals within the date range do not match!";
+
+    private final DateRange dateRange;
+    private final DateInterval dateInterval;
+    private final List<DateRange> timelineIntervals;
+    private final List<Amount> aggregateExpenses;
+
+    /**
+     * Creates a new ExpenseTimeline with the given parameters.
+     * @param dateRange The range of dates that the timeline spans.
+     * @param dateInterval The level of "granularity" that the aggregate expenses are shown in
+     * @param aggregateExpenses List of aggregate amounts. The nth element represents the aggregate expense of all
+     *                          expenses that occurred between {@code start + n * dateInterval} and {@code start
+     *                          + (n + 1) * dateInterval}.
+     * @throws IllegalValueException if the size of the aggregate expense list and the number of intervals in the date
+     *                               range do not match.
+     */
+    public ExpenseTimeline(DateRange dateRange, DateInterval dateInterval, List<Amount> aggregateExpenses)
+            throws IllegalValueException {
+        this.dateRange = dateRange;
+        this.dateInterval = dateInterval;
+        this.timelineIntervals = dateRange.partitionByInterval(dateInterval);
+        this.aggregateExpenses = aggregateExpenses;
+
+        if (timelineIntervals.size() != aggregateExpenses.size()) {
+            throw new IllegalValueException(INVALID_PARAMETERS_MESSAGE);
+        }
+    }
+
+    /**
+     * Getter for date range.
+     * @return Date range that the timeline spans.
+     */
+    public DateRange getDateRange() {
+        return dateRange;
+    }
+
+    /**
+     * Getter for time interval used.
+     * @return Time interval used, as a {@code ChronoUnit}.
+     */
+    public DateInterval getDateInterval() {
+        return dateInterval;
+    }
+
+    /**
+     * List for the aggregate expenses between {@code start} and {@code end} dates.
+     * @return A list of aggregate expenses.
+     */
+    public List<Amount> getAggregateExpenses() {
+        return aggregateExpenses;
+    }
+
+    /**
+     * Map representing the aggregate expenses over a timeline. The keys are {@code DateRange}s with duration equal to
+     * the given interval, and the values are the aggregate expenses over that date range.
+     * @return Map representing the timeline.
+     */
+    public Map<DateRange, Amount> getTimeline() {
+        return IntStream.range(0, timelineIntervals.size())
+                .boxed()
+                .collect(Collectors.toMap(timelineIntervals::get, aggregateExpenses::get));
+    }
+}

--- a/src/main/java/seedu/billboard/model/statistics/ExpenseTimeline.java
+++ b/src/main/java/seedu/billboard/model/statistics/ExpenseTimeline.java
@@ -1,5 +1,8 @@
 package seedu.billboard.model.statistics;
 
+import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,6 +38,9 @@ public class ExpenseTimeline {
      */
     public ExpenseTimeline(DateRange dateRange, DateInterval dateInterval, List<Amount> aggregateExpenses)
             throws IllegalValueException {
+
+        requireAllNonNull(dateRange, dateInterval, aggregateExpenses);
+
         this.dateRange = dateRange;
         this.dateInterval = dateInterval;
         this.timelineIntervals = dateRange.partitionByInterval(dateInterval);
@@ -71,12 +77,14 @@ public class ExpenseTimeline {
 
     /**
      * Map representing the aggregate expenses over a timeline. The keys are {@code DateRange}s with duration equal to
-     * the given interval, and the values are the aggregate expenses over that date range.
+     * the given interval, and the values are the aggregate expenses over that date range. The output map has a
+     * predictable chronological ordering when iterated.
      * @return Map representing the timeline.
      */
     public Map<DateRange, Amount> getTimeline() {
         return IntStream.range(0, timelineIntervals.size())
                 .boxed()
-                .collect(Collectors.toMap(timelineIntervals::get, aggregateExpenses::get));
+                .collect(Collectors.toMap(timelineIntervals::get, aggregateExpenses::get,
+                        Amount::add, LinkedHashMap::new));
     }
 }

--- a/src/main/java/seedu/billboard/model/statistics/ExpenseTimeline.java
+++ b/src/main/java/seedu/billboard/model/statistics/ExpenseTimeline.java
@@ -1,90 +1,39 @@
 package seedu.billboard.model.statistics;
 
-import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
-
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import seedu.billboard.commons.core.date.DateInterval;
 import seedu.billboard.commons.core.date.DateRange;
-import seedu.billboard.commons.exceptions.IllegalValueException;
 import seedu.billboard.model.expense.Amount;
 
 /**
- * Represents the aggregate expenses for every interval of time, over a specified range of time
+ * Interface representing the timeline view of a set of expenses.
  */
-public class ExpenseTimeline {
-
-    private static final String INVALID_PARAMETERS_MESSAGE = "Number of aggregate expenses and number of date "
-            + "intervals within the date range do not match!";
-
-    private final DateRange dateRange;
-    private final DateInterval dateInterval;
-    private final List<DateRange> timelineIntervals;
-    private final List<Amount> aggregateExpenses;
-
-    /**
-     * Creates a new ExpenseTimeline with the given parameters.
-     * @param dateRange The range of dates that the timeline spans.
-     * @param dateInterval The level of "granularity" that the aggregate expenses are shown in
-     * @param aggregateExpenses List of aggregate amounts. The nth element represents the aggregate expense of all
-     *                          expenses that occurred between {@code start + n * dateInterval} and {@code start
-     *                          + (n + 1) * dateInterval}.
-     * @throws IllegalValueException if the size of the aggregate expense list and the number of intervals in the date
-     *                               range do not match.
-     */
-    public ExpenseTimeline(DateRange dateRange, DateInterval dateInterval, List<Amount> aggregateExpenses)
-            throws IllegalValueException {
-
-        requireAllNonNull(dateRange, dateInterval, aggregateExpenses);
-
-        this.dateRange = dateRange;
-        this.dateInterval = dateInterval;
-        this.timelineIntervals = dateRange.partitionByInterval(dateInterval);
-        this.aggregateExpenses = aggregateExpenses;
-
-        if (timelineIntervals.size() != aggregateExpenses.size()) {
-            throw new IllegalValueException(INVALID_PARAMETERS_MESSAGE);
-        }
-    }
+public interface ExpenseTimeline {
 
     /**
      * Getter for date range.
      * @return Date range that the timeline spans.
      */
-    public DateRange getDateRange() {
-        return dateRange;
-    }
+    DateRange getDateRange();
 
     /**
      * Getter for time interval used.
-     * @return Time interval used, as a {@code ChronoUnit}.
+     * @return Time interval used, as a {@code DateInterval}.
      */
-    public DateInterval getDateInterval() {
-        return dateInterval;
-    }
+    DateInterval getDateInterval();
 
     /**
      * List for the aggregate expenses between {@code start} and {@code end} dates.
      * @return A list of aggregate expenses.
      */
-    public List<Amount> getAggregateExpenses() {
-        return aggregateExpenses;
-    }
+    List<Amount> getTotalAmounts();
 
     /**
      * Map representing the aggregate expenses over a timeline. The keys are {@code DateRange}s with duration equal to
-     * the given interval, and the values are the aggregate expenses over that date range. The output map has a
-     * predictable chronological ordering when iterated.
+     * the given interval, and the values are the aggregate expenses over that date range.
      * @return Map representing the timeline.
      */
-    public Map<DateRange, Amount> getTimeline() {
-        return IntStream.range(0, timelineIntervals.size())
-                .boxed()
-                .collect(Collectors.toMap(timelineIntervals::get, aggregateExpenses::get,
-                        Amount::add, LinkedHashMap::new));
-    }
+    Map<DateRange, Amount> getTimeline();
 }

--- a/src/main/java/seedu/billboard/model/statistics/FilledExpenseTimeline.java
+++ b/src/main/java/seedu/billboard/model/statistics/FilledExpenseTimeline.java
@@ -1,0 +1,112 @@
+package seedu.billboard.model.statistics;
+
+import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.commons.core.date.DateRange;
+import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.Expense;
+
+/**
+ * Represents the aggregate expenses for every interval of time, over a specified range of time
+ */
+public class FilledExpenseTimeline implements ExpenseTimeline {
+
+
+    private static final String INVALID_PARAMETERS_MESSAGE = "Number of aggregate expenses and number of date "
+            + "intervals within the date range do not match!";
+
+    private final DateRange dateRange;
+    private final DateInterval dateInterval;
+    private final List<DateRange> timelineIntervals;
+    private final List<List<Expense>> aggregateExpenses;
+
+    /**
+     * Creates a new ExpenseTimeline with the given parameters.
+     *
+     * @param dateRange         The range of dates that the timeline spans.
+     * @param dateInterval      The level of "granularity" that the aggregate expenses are shown in
+     * @param aggregateExpenses List of aggregate expenses. The nth element represents a list of the all the expenses
+     *                          that occurred between {@code start + n * dateInterval} and {@code start
+     *                          + (n + 1) * dateInterval}.
+     * @throws IllegalArgumentException if the size of the aggregate expense list and the number of intervals in the
+     *                                  date range do not match.
+     */
+    public FilledExpenseTimeline(DateRange dateRange, DateInterval dateInterval, List<List<Expense>> aggregateExpenses)
+            throws IllegalArgumentException {
+
+        requireAllNonNull(dateRange, dateInterval, aggregateExpenses);
+
+        this.dateRange = dateRange;
+        this.dateInterval = dateInterval;
+        this.timelineIntervals = dateRange.partitionByInterval(dateInterval);
+        this.aggregateExpenses = aggregateExpenses;
+
+        if (timelineIntervals.size() != aggregateExpenses.size()) {
+            throw new IllegalArgumentException(INVALID_PARAMETERS_MESSAGE);
+        }
+    }
+
+    /**
+     * Getter for date range.
+     *
+     * @return Date range that the timeline spans.
+     */
+    public DateRange getDateRange() {
+        return dateRange;
+    }
+
+    /**
+     * Getter for time interval used.
+     *
+     * @return Time interval used, as a {@code DateInterval}.
+     */
+    public DateInterval getDateInterval() {
+        return dateInterval;
+    }
+
+    /**
+     * List with each aggregate expense as an {@code Amount} between {@code start} and {@code end} dates.
+     *
+     * @return A list of aggregate expenses.
+     */
+    public List<Amount> getTotalAmounts() {
+        return aggregateExpenses.stream()
+                .map(this::totalAmount)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the {@code Amount} representing the total amount of all the expenses.
+     *
+     * @param expenses List of expenses.
+     * @return Total amount.
+     */
+    private Amount totalAmount(List<Expense> expenses) {
+        return expenses.stream()
+                .reduce(new Amount("0"), (amount, expense) -> amount.add(expense.getAmount()),
+                        Amount::add);
+    }
+
+    /**
+     * Map representing the aggregate expenses over a timeline. The keys are {@code DateRange}s with duration equal to
+     * the given interval, and the values are the aggregate expenses over that date range. The output map has a
+     * predictable chronological ordering when iterated.
+     *
+     * @return Map representing the timeline.
+     */
+    public Map<DateRange, Amount> getTimeline() {
+        return IntStream.range(0, timelineIntervals.size())
+                .boxed()
+                .collect(Collectors.toMap(timelineIntervals::get,
+                    index -> totalAmount(aggregateExpenses.get(index)),
+                    Amount::add,
+                    LinkedHashMap::new));
+    }
+}

--- a/src/main/java/seedu/billboard/model/statistics/Statistics.java
+++ b/src/main/java/seedu/billboard/model/statistics/Statistics.java
@@ -1,0 +1,27 @@
+package seedu.billboard.model.statistics;
+
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.model.expense.Expense;
+
+import java.util.List;
+
+/**
+ * Interface for generating statistics.
+ */
+public interface Statistics {
+
+    /**
+     * Generates an expense timeline based on the given list of expenses, with a default date interval of a month.
+     * @param expenses Input expenses.
+     * @return An expense timeline.
+     */
+    ExpenseTimeline generateExpenseTimeline(List<Expense> expenses);
+
+    /**
+     * Generates an expense timeline based on the given list of expenses, and the specified date interval
+     * @param expenses Input expenses.
+     * @param interval Specified date interval.
+     * @return An expense timeline.
+     */
+    ExpenseTimeline generateExpenseTimeline(List<Expense> expenses, DateInterval interval);
+}

--- a/src/main/java/seedu/billboard/model/statistics/Statistics.java
+++ b/src/main/java/seedu/billboard/model/statistics/Statistics.java
@@ -12,13 +12,15 @@ public interface Statistics {
 
     /**
      * Generates an expense timeline based on the given list of expenses, with a default date interval of a month.
-     * @param expenses Input expenses.
+     *
+     * @param expenses Input expenses list.
      * @return An expense timeline.
      */
     ExpenseTimeline generateExpenseTimeline(List<Expense> expenses);
 
     /**
      * Generates an expense timeline based on the given list of expenses, and the specified date interval
+     *
      * @param expenses Input expenses.
      * @param interval Specified date interval.
      * @return An expense timeline.

--- a/src/main/java/seedu/billboard/model/statistics/Statistics.java
+++ b/src/main/java/seedu/billboard/model/statistics/Statistics.java
@@ -1,9 +1,9 @@
 package seedu.billboard.model.statistics;
 
+import java.util.List;
+
 import seedu.billboard.commons.core.date.DateInterval;
 import seedu.billboard.model.expense.Expense;
-
-import java.util.List;
 
 /**
  * Interface for generating statistics.

--- a/src/main/java/seedu/billboard/model/statistics/StatisticsGenerator.java
+++ b/src/main/java/seedu/billboard/model/statistics/StatisticsGenerator.java
@@ -1,0 +1,22 @@
+package seedu.billboard.model.statistics;
+
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.model.expense.Expense;
+
+import java.util.List;
+
+/**
+ * Stateless class to generate statistics. Every method is a pure function, taking in a list of expenses and other
+ * specified options and returning an object representing the desired statistic, with no side effects.
+ */
+public class StatisticsGenerator implements Statistics {
+    @Override
+    public ExpenseTimeline generateExpenseTimeline(List<Expense> expenses) {
+        return generateExpenseTimeline(expenses, DateInterval.MONTH);
+    }
+
+    @Override
+    public ExpenseTimeline generateExpenseTimeline(List<Expense> expenses, DateInterval interval) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/billboard/model/statistics/StatisticsGenerator.java
+++ b/src/main/java/seedu/billboard/model/statistics/StatisticsGenerator.java
@@ -1,8 +1,14 @@
 package seedu.billboard.model.statistics;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.commons.core.date.DateRange;
+import seedu.billboard.commons.util.CollectionUtil;
 import seedu.billboard.model.expense.Expense;
 
 /**
@@ -17,6 +23,51 @@ public class StatisticsGenerator implements Statistics {
 
     @Override
     public ExpenseTimeline generateExpenseTimeline(List<Expense> expenses, DateInterval interval) {
-        return null;
+        if (!CollectionUtil.checkNonEmpty(expenses)) {
+            return new EmptyExpenseTimeline();
+        }
+
+        List<Expense> sortedExpenses = expenses.stream()
+                .sorted(Comparator.comparing(expense -> expense.getCreated().dateTime))
+                .collect(Collectors.toList());
+
+        LocalDateTime startDateTime = sortedExpenses.get(0).getCreated().dateTime;
+        LocalDateTime endDateTime = sortedExpenses.get(sortedExpenses.size() - 1).getCreated().dateTime;
+
+        DateRange dateRange = new DateRange(startDateTime.toLocalDate(), endDateTime.toLocalDate());
+
+
+        return new FilledExpenseTimeline(dateRange, interval,
+                getAggregateExpensesFromSorted(dateRange.partitionByInterval(interval), sortedExpenses));
+    }
+
+    /**
+     * Preconditions: {@code ranges} and {@code expenses} are both sorted chronologically.
+     */
+    private List<List<Expense>> getAggregateExpensesFromSorted(List<DateRange> ranges, List<Expense> expenses) {
+        List<List<Expense>> aggregateExpenses = new ArrayList<>();
+        List<Expense> listView = expenses;
+
+        for (var range : ranges) {
+            List<Expense> aggregateExpense = extractExpensesInDateRange(listView, range);
+
+            aggregateExpenses.add(aggregateExpense);
+            listView = listView.subList(aggregateExpense.size(), listView.size());
+        }
+
+        return aggregateExpenses;
+    }
+
+    /**
+     * Returns the sublist of expenses from the that occur within the specified date range. The input expense list must
+     * be sorted chronologically.
+     * @param expenses Chronologically sorted expense list.
+     * @param range Desired date range for output list to be contained within.
+     * @return List of expenses that occur within specified date range.
+     */
+    private List<Expense> extractExpensesInDateRange(List<Expense> expenses, DateRange range) {
+        return expenses.stream()
+                        .takeWhile(expense -> range.contains(expense.getCreated().dateTime.toLocalDate()))
+                        .collect(Collectors.toList());
     }
 }

--- a/src/main/java/seedu/billboard/model/statistics/StatisticsGenerator.java
+++ b/src/main/java/seedu/billboard/model/statistics/StatisticsGenerator.java
@@ -1,9 +1,9 @@
 package seedu.billboard.model.statistics;
 
+import java.util.List;
+
 import seedu.billboard.commons.core.date.DateInterval;
 import seedu.billboard.model.expense.Expense;
-
-import java.util.List;
 
 /**
  * Stateless class to generate statistics. Every method is a pure function, taking in a list of expenses and other

--- a/src/main/java/seedu/billboard/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/billboard/model/util/SampleDataUtil.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import seedu.billboard.model.Billboard;
 import seedu.billboard.model.ReadOnlyBillboard;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
@@ -19,17 +20,17 @@ public class SampleDataUtil {
     public static Expense[] getSampleExpenses() {
         return new Expense[] {
             new Expense(new Name("buy tea"), new Description("tea from foodclique"),
-                    new Amount("1.23"), getTagSet("com1")),
+                    new Amount("1.23"), new CreatedDateTime("12/12/2018"), getTagSet("com1")),
             new Expense(new Name("buy kopiO"), new Description(""),
-                    new Amount("1.50"), getTagSet("com2")),
+                    new Amount("1.50"), new CreatedDateTime("13/04/2019 2359"), getTagSet("com2")),
             new Expense(new Name("buy lunch"), new Description("chicken rice from deck"),
-                    new Amount("3.70"), getTagSet("thedeck")),
+                    new Amount("3.70"),new CreatedDateTime("1/1/2018"), getTagSet("thedeck")),
             new Expense(new Name("buy book"), new Description("so expensive wtf"),
-                    new Amount("77.3"), getTagSet("coop")),
+                    new Amount("77.3"), new CreatedDateTime("3/05/2019"), getTagSet("coop")),
             new Expense(new Name("bride prof"), new Description(""),
-                    new Amount("500.00"), getTagSet("LT13")),
+                    new Amount("500.00"), new CreatedDateTime("31/12/2018 1200"), getTagSet("LT13")),
             new Expense(new Name("buy weed"), new Description("jk haha"),
-                    new Amount("150.00"), getTagSet("PGP"))
+                    new Amount("150.00"), new CreatedDateTime("10/10/2019"), getTagSet("PGP"))
         };
     }
 

--- a/src/main/java/seedu/billboard/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/billboard/model/util/SampleDataUtil.java
@@ -24,7 +24,7 @@ public class SampleDataUtil {
             new Expense(new Name("buy kopiO"), new Description(""),
                     new Amount("1.50"), new CreatedDateTime("13/04/2019 2359"), getTagSet("com2")),
             new Expense(new Name("buy lunch"), new Description("chicken rice from deck"),
-                    new Amount("3.70"),new CreatedDateTime("1/1/2018"), getTagSet("thedeck")),
+                    new Amount("3.70"), new CreatedDateTime("1/1/2018"), getTagSet("thedeck")),
             new Expense(new Name("buy book"), new Description("so expensive wtf"),
                     new Amount("77.3"), new CreatedDateTime("3/05/2019"), getTagSet("coop")),
             new Expense(new Name("bride prof"), new Description(""),

--- a/src/main/java/seedu/billboard/storage/JsonAdaptedExpense.java
+++ b/src/main/java/seedu/billboard/storage/JsonAdaptedExpense.java
@@ -1,5 +1,8 @@
 package seedu.billboard.storage;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -11,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.billboard.commons.exceptions.IllegalValueException;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
@@ -22,10 +26,12 @@ import seedu.billboard.model.tag.Tag;
 class JsonAdaptedExpense {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Expense's %s field is missing!";
+    private static final DateTimeFormatter dateStoragePattern = DateTimeFormatter.ofPattern("dd/MM/yyyy HHmm");
 
     private final String name;
     private final String description;
     private final String amount;
+    private final String created;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -34,10 +40,12 @@ class JsonAdaptedExpense {
     @JsonCreator
     public JsonAdaptedExpense(@JsonProperty("name") String name, @JsonProperty("description") String description,
                               @JsonProperty("amount") String amount,
+                              @JsonProperty("created") String created,
                               @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.description = description;
         this.amount = amount;
+        this.created = created;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -50,6 +58,7 @@ class JsonAdaptedExpense {
         name = source.getName().name;
         description = source.getDescription().description;
         amount = source.getAmount().toString();
+        created = source.getCreated().dateTime.format(dateStoragePattern);
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -82,6 +91,7 @@ class JsonAdaptedExpense {
             throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
         }
         final Description modelDescription = new Description(description);
+
         if (amount == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName()));
         }
@@ -90,8 +100,20 @@ class JsonAdaptedExpense {
         }
         final Amount modelAmount = new Amount(amount);
 
+        if (created == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, CreatedDateTime.class.getSimpleName()));
+        }
+        LocalDateTime dateTime;
+        try {
+            dateTime = dateStoragePattern.parse(created, LocalDateTime::from);
+        } catch (DateTimeParseException e) {
+            throw new IllegalValueException(CreatedDateTime.MESSAGE_CONSTRAINTS);
+        }
+        final CreatedDateTime modelCreated = new CreatedDateTime(dateTime);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Expense(modelName, modelDescription, modelAmount, modelTags);
+        return new Expense(modelName, modelDescription, modelAmount, modelCreated, modelTags);
     }
 
 }

--- a/src/main/java/seedu/billboard/storage/JsonSerializableBillboard.java
+++ b/src/main/java/seedu/billboard/storage/JsonSerializableBillboard.java
@@ -16,7 +16,7 @@ import seedu.billboard.model.expense.Expense;
 /**
  * An Immutable Billboard that is serializable to JSON format.
  */
-@JsonRootName(value = "addressbook")
+@JsonRootName(value = "billboard")
 class JsonSerializableBillboard {
 
     public static final String MESSAGE_DUPLICATE_EXPENSE = "Expenses list contains duplicate expense(s).";

--- a/src/test/data/JsonBillboardStorageTest/invalidAndValidExpenseBillboard.json
+++ b/src/test/data/JsonBillboardStorageTest/invalidAndValidExpenseBillboard.json
@@ -3,11 +3,13 @@
     "name" : "valid expense",
     "description" : "tickets to joker",
     "amount" : "10.00",
+    "created" : "12/31/2019 1234",
     "tagged" : [ "leisure" ]
   }, {
     "name": "Expense With Invalid Amount Field",
     "description" : "toast with frens",
     "amount" : "4.20 blaze it",
+    "created" : "01/01/2019 0101",
     "tagged" : [ "monday", "friends" ]
   } ]
 }

--- a/src/test/data/JsonBillboardStorageTest/invalidExpenseBillboard.json
+++ b/src/test/data/JsonBillboardStorageTest/invalidExpenseBillboard.json
@@ -2,6 +2,7 @@
   "expenses": [ {
     "name": "Expense with invalid name field: Ha!ns Mu@ster",
     "description": "blaaaa",
-    "amount": "123,45"
+    "amount": "123,45",
+    "created": "first january"
   } ]
 }

--- a/src/test/data/JsonSerializableBillboardTest/duplicateExpensesBillboard.json
+++ b/src/test/data/JsonSerializableBillboardTest/duplicateExpensesBillboard.json
@@ -3,11 +3,13 @@
     "name" : "movie tickets",
     "description" : "tickets to joker",
     "amount" : "10.00",
+    "created" : "31/12/2019 1234",
     "tagged" : [ "leisure" ]
   }, {
     "name" : "movie tickets",
     "description" : "tickets to joker",
     "amount" : "10.00",
+    "created" : "31/12/2019 1234",
     "tagged" : [ "leisure" ]
   } ]
 }

--- a/src/test/data/JsonSerializableBillboardTest/invalidExpenseBillboard.json
+++ b/src/test/data/JsonSerializableBillboardTest/invalidExpenseBillboard.json
@@ -3,6 +3,7 @@
     "name" : "movie tickets",
     "description" : null,
     "amount" : "blah",
+    "created" : "bluh",
     "tagged" : [ "leisure" ]
   } ]
 }

--- a/src/test/data/JsonSerializableBillboardTest/typicalExpensesBillboard.json
+++ b/src/test/data/JsonSerializableBillboardTest/typicalExpensesBillboard.json
@@ -16,7 +16,7 @@
     "name" : "groceries",
     "description" : "bought from fairprice",
     "amount" : "23.50",
-    "created" : "12/01/2019 1200",
+    "created" : "12/02/2019 1200",
     "tagged" : [ ]
   }, {
     "name" : "movie tickets",

--- a/src/test/data/JsonSerializableBillboardTest/typicalExpensesBillboard.json
+++ b/src/test/data/JsonSerializableBillboardTest/typicalExpensesBillboard.json
@@ -1,24 +1,28 @@
 {
-  "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
+  "_comment": "Billboard save file which contains the same Expense values as in TypicalExpenses#getTypicalBillboard()",
   "expenses" : [ {
     "name" : "monthly bills",
     "description" : "pay phone company",
     "amount" : "350.25",
+    "created" : "09/09/2018 2152",
     "tagged" : [ "bills" ]
   }, {
     "name" : "monday breakfast food",
     "description" : "toast with frens",
     "amount" : "4.20",
+    "created" : "12/01/2019 0000",
     "tagged" : [ "monday", "friends" ]
   }, {
     "name" : "groceries",
     "description" : "bought from fairprice",
     "amount" : "23.50",
+    "created" : "12/01/2019 1200",
     "tagged" : [ ]
   }, {
     "name" : "movie tickets",
     "description" : "tickets to joker",
     "amount" : "10.00",
+    "created" : "01/01/2019 0530",
     "tagged" : [ "leisure" ]
   } ]
 }

--- a/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
+++ b/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.billboard.testutil.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
-import seedu.billboard.commons.exceptions.IllegalValueException;
-
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Month;
@@ -15,6 +12,10 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
+import seedu.billboard.commons.exceptions.IllegalValueException;
+
 
 public class DateRangeTest {
 
@@ -22,7 +23,7 @@ public class DateRangeTest {
     private LocalDate endDate = LocalDate.of(2019, 4, 13);
 
     @Test
-    public void constructor_GivenValidDates_ReturnsEquivalentDateRange() throws IllegalValueException {
+    public void constructor_givenValidDates_returnsEquivalentDateRange() throws IllegalValueException {
         DateRange dateRange = new DateRange(startDate, endDate);
 
         assertEquals(startDate, dateRange.getStartDate());
@@ -35,12 +36,12 @@ public class DateRangeTest {
     }
 
     @Test
-    public void constructor_GivenEndDateEarlierThanStartDate_ThrowsException() {
+    public void constructor_givenEndDateEarlierThanStartDate_throwsException() {
         assertThrows(IllegalValueException.class, () -> new DateRange(endDate, startDate));
     }
 
     @Test
-    public void partitionByInterval_WeeklyInterval_ExpectedList() throws IllegalValueException {
+    public void partitionByInterval_weeklyInterval_expectedList() throws IllegalValueException {
         DateRange dateRange = new DateRange(startDate, endDate);
         DateInterval weekInterval = DateInterval.WEEK;
 
@@ -62,7 +63,7 @@ public class DateRangeTest {
         }
     }
 
-    @Test void partitionByInterval_MonthlyInterval_ExpectedList() throws IllegalValueException {
+    @Test void partitionByInterval_monthlyInterval_expectedList() throws IllegalValueException {
         LocalDate startDate = LocalDate.of(2018, Month.DECEMBER, 6);
         LocalDate endDate = LocalDate.of(2019, Month.FEBRUARY, 13);
         DateRange range = new DateRange(startDate, endDate);
@@ -90,7 +91,7 @@ public class DateRangeTest {
 
 
     @Test
-    public void partitionByInterval_IntervalLargerThanDateRange_ListOfSizeOne() throws IllegalValueException {
+    public void partitionByInterval_intervalLargerThanDateRange_listOfSizeOne() throws IllegalValueException {
         DateRange dateRange = new DateRange(LocalDate.of(2019, 1, 1),
                 LocalDate.of(2019, 1, 2));
         DateInterval yearInterval = DateInterval.YEAR;

--- a/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
+++ b/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
@@ -1,0 +1,129 @@
+package seedu.billboard.commons.core.date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.billboard.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import seedu.billboard.commons.exceptions.IllegalValueException;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+
+public class DateRangeTest {
+
+    private LocalDate startDate = LocalDate.of(2018, 4, 13);
+    private LocalDate endDate = LocalDate.of(2019, 4, 13);
+
+    @Test
+    public void constructor_GivenValidDates_ReturnsEquivalentDateRange() throws IllegalValueException {
+        DateRange dateRange = new DateRange(startDate, endDate);
+
+        assertEquals(startDate, dateRange.getStartDate());
+        assertEquals(endDate, dateRange.getEndDate());
+
+        DateRange sameStartAndEndDateRange = new DateRange(startDate, startDate);
+
+        assertEquals(startDate, sameStartAndEndDateRange.getStartDate());
+        assertEquals(startDate, sameStartAndEndDateRange.getEndDate());
+    }
+
+    @Test
+    public void constructor_GivenEndDateEarlierThanStartDate_ThrowsException() {
+        assertThrows(IllegalValueException.class, () -> new DateRange(endDate, startDate));
+    }
+
+    @Test
+    public void partitionByInterval_WeeklyInterval_ExpectedList() throws IllegalValueException {
+        DateRange dateRange = new DateRange(startDate, endDate);
+        DateInterval weekInterval = DateInterval.WEEK;
+
+        List<DateRange> partitioned = dateRange.partitionByInterval(weekInterval);
+
+        LocalDate expectedStart = startDate.with(TemporalAdjusters.previous(DayOfWeek.MONDAY));
+        LocalDate expectedEndExclusive = endDate.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+
+        long expectedNumberOfIntervals = ChronoUnit.WEEKS.between(expectedStart, expectedEndExclusive);
+
+        assertEquals(expectedNumberOfIntervals, partitioned.size()); // size correct
+        assertEquals(expectedStart, partitioned.get(0).getStartDate()); // start date equal
+        assertEquals(expectedEndExclusive.minus(Period.ofDays(1)),
+                partitioned.get(partitioned.size() - 1).getEndDate()); // end date equal
+
+        for (var range : partitioned) { // all date ranges correct
+            assertEquals(weekInterval.getPeriod(),
+                    periodBetweenInclusive(range.getStartDate(), range.getEndDate()));
+        }
+    }
+
+    @Test void partitionByInterval_MonthlyInterval_ExpectedList() throws IllegalValueException {
+        LocalDate startDate = LocalDate.of(2018, Month.DECEMBER, 6);
+        LocalDate endDate = LocalDate.of(2019, Month.FEBRUARY, 13);
+        DateRange range = new DateRange(startDate, endDate);
+
+        List<DateRange> partitioned = range.partitionByInterval(DateInterval.MONTH);
+
+        assertEquals(3, partitioned.size());
+
+        // contains December
+        DateRange dec = partitioned.get(0);
+        assertEquals(LocalDate.of(2018, Month.DECEMBER, 1), dec.getStartDate());
+        assertEquals(LocalDate.of(2018, Month.DECEMBER, 31), dec.getEndDate());
+
+        // contains January
+        DateRange jan = partitioned.get(1);
+        assertEquals(LocalDate.of(2019, Month.JANUARY, 1), jan.getStartDate());
+        assertEquals(LocalDate.of(2019, Month.JANUARY, 31), jan.getEndDate());
+
+        // contains February
+        DateRange feb = partitioned.get(2);
+        assertEquals(LocalDate.of(2019, Month.FEBRUARY, 1), feb.getStartDate());
+        assertEquals(LocalDate.of(2019, Month.FEBRUARY, 28), feb.getEndDate());
+    }
+
+
+
+    @Test
+    public void partitionByInterval_IntervalLargerThanDateRange_ListOfSizeOne() throws IllegalValueException {
+        DateRange dateRange = new DateRange(LocalDate.of(2019, 1, 1),
+                LocalDate.of(2019, 1, 2));
+        DateInterval yearInterval = DateInterval.YEAR;
+
+        List<DateRange> partitioned = dateRange.partitionByInterval(yearInterval);
+
+        assertEquals(1, partitioned.size());
+        DateRange dateRangeOfInterval = partitioned.get(0);
+        assertEquals(yearInterval.getPeriod(),
+                periodBetweenInclusive(dateRangeOfInterval.getStartDate(), dateRangeOfInterval.getEndDate()));
+    }
+
+    @Test
+    public void equals() throws IllegalValueException {
+        DateRange range1 = new DateRange(startDate, endDate);
+        DateRange range2 = new DateRange(startDate, endDate);
+
+        assertEquals(range1, range2); // same start and end dates
+
+        DateRange range3 = new DateRange(startDate, LocalDate.of(2018, 6, 12));
+
+        assertNotEquals(range3, range1); // different end date
+
+        DateRange range4 = new DateRange(LocalDate.MIN, endDate);
+
+        assertNotEquals(range4, range1); // different start date
+
+        DateRange range5 = new DateRange(LocalDate.MIN, LocalDate.MAX);
+
+        assertNotEquals(range5, range1); // different start and end dates
+    }
+
+    private Period periodBetweenInclusive(LocalDate startDateInclusive, LocalDate endDateInclusive) {
+        return Period.between(startDateInclusive, endDateInclusive.plus(Period.ofDays(1)));
+    }
+}

--- a/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
+++ b/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
@@ -37,11 +37,11 @@ public class DateRangeTest {
 
     @Test
     public void constructor_givenEndDateEarlierThanStartDate_throwsException() {
-        assertThrows(IllegalValueException.class, () -> new DateRange(endDate, startDate));
+        assertThrows(IllegalArgumentException.class, () -> new DateRange(endDate, startDate));
     }
 
     @Test
-    public void partitionByInterval_weeklyInterval_expectedList() throws IllegalValueException {
+    public void partitionByInterval_weeklyInterval_expectedList() {
         DateRange dateRange = new DateRange(startDate, endDate);
         DateInterval weekInterval = DateInterval.WEEK;
 
@@ -63,7 +63,7 @@ public class DateRangeTest {
         }
     }
 
-    @Test void partitionByInterval_monthlyInterval_expectedList() throws IllegalValueException {
+    @Test void partitionByInterval_monthlyInterval_expectedList() {
         LocalDate startDate = LocalDate.of(2018, Month.DECEMBER, 6);
         LocalDate endDate = LocalDate.of(2019, Month.FEBRUARY, 13);
         DateRange range = new DateRange(startDate, endDate);
@@ -91,7 +91,7 @@ public class DateRangeTest {
 
 
     @Test
-    public void partitionByInterval_intervalLargerThanDateRange_listOfSizeOne() throws IllegalValueException {
+    public void partitionByInterval_intervalLargerThanDateRange_listOfSizeOne() {
         DateRange dateRange = new DateRange(LocalDate.of(2019, 1, 1),
                 LocalDate.of(2019, 1, 2));
         DateInterval yearInterval = DateInterval.YEAR;
@@ -105,7 +105,7 @@ public class DateRangeTest {
     }
 
     @Test
-    public void equals() throws IllegalValueException {
+    public void equals() {
         DateRange range1 = new DateRange(startDate, endDate);
         DateRange range2 = new DateRange(startDate, endDate);
 

--- a/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
+++ b/src/test/java/seedu/billboard/commons/core/date/DateRangeTest.java
@@ -1,7 +1,9 @@
 package seedu.billboard.commons.core.date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.billboard.testutil.Assert.assertThrows;
 
 import java.time.DayOfWeek;
@@ -14,8 +16,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.billboard.commons.exceptions.IllegalValueException;
-
 
 public class DateRangeTest {
 
@@ -23,7 +23,7 @@ public class DateRangeTest {
     private LocalDate endDate = LocalDate.of(2019, 4, 13);
 
     @Test
-    public void constructor_givenValidDates_returnsEquivalentDateRange() throws IllegalValueException {
+    public void constructor_givenValidDates_returnsEquivalentDateRange() {
         DateRange dateRange = new DateRange(startDate, endDate);
 
         assertEquals(startDate, dateRange.getStartDate());
@@ -38,6 +38,38 @@ public class DateRangeTest {
     @Test
     public void constructor_givenEndDateEarlierThanStartDate_throwsException() {
         assertThrows(IllegalArgumentException.class, () -> new DateRange(endDate, startDate));
+    }
+
+    @Test
+    public void overPeriod() {
+        // normal period
+        DateRange actual = DateRange.overPeriod(startDate, Period.of(0, 1, 2));
+        DateRange expected = new DateRange(startDate, LocalDate.of(2018, 5, 14));
+        assertEquals(expected, actual);
+
+        // zero period
+        assertThrows(IllegalArgumentException.class, () -> DateRange.overPeriod(startDate, Period.ZERO));
+
+        // negative period
+        assertThrows(IllegalArgumentException.class, () ->
+                DateRange.overPeriod(startDate, Period.of(-1, 1, 1)));
+    }
+
+    @Test
+    public void contains() {
+        DateRange dateRange = new DateRange(startDate, endDate);
+
+        assertTrue(dateRange.contains(LocalDate.of(2019, 1, 6)));
+        assertFalse(dateRange.contains(LocalDate.of(2019, 4, 14)));
+
+        // value same as start date, returns true
+        assertTrue(dateRange.contains(startDate));
+
+        // value same as end date, returns true
+        assertTrue(dateRange.contains(endDate));
+
+        // One day date range contains itself
+        assertTrue(new DateRange(startDate, startDate).contains(startDate));
     }
 
     @Test

--- a/src/test/java/seedu/billboard/commons/util/CollectionUtilTest.java
+++ b/src/test/java/seedu/billboard/commons/util/CollectionUtilTest.java
@@ -5,12 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.billboard.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.billboard.testutil.Assert.assertThrows;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.billboard.commons.core.date.DateInterval;
 
 public class CollectionUtilTest {
     @Test
@@ -65,12 +69,24 @@ public class CollectionUtilTest {
         assertNullPointerExceptionNotThrown(Collections.emptyList());
 
         // list with all non-null elements
-        assertNullPointerExceptionNotThrown(Arrays.asList(new Object(), "ham", Integer.valueOf(1)));
+        assertNullPointerExceptionNotThrown(Arrays.asList(new Object(), "ham", 1));
         assertNullPointerExceptionNotThrown(Arrays.asList(new Object()));
 
         // confirms nulls inside nested lists are not considered
         List<Object> containingNull = Arrays.asList((Object) null);
         assertNullPointerExceptionNotThrown(Arrays.asList(containingNull, new Object()));
+    }
+
+    @Test
+    public void checkNonEmpty() {
+        assertTrue(CollectionUtil.checkNonEmpty(List.of(1, 2, 3, 4)));
+        assertTrue(CollectionUtil.checkNonEmpty(Set.of(new Object(), new Object())));
+        assertTrue(CollectionUtil.checkNonEmpty(Collections.singletonList(DateInterval.MONTH)));
+
+        assertFalse(CollectionUtil.checkNonEmpty(new ArrayList<>()));
+        assertFalse(CollectionUtil.checkNonEmpty(Set.of()));
+
+        assertThrows(NullPointerException.class, () -> CollectionUtil.checkNonEmpty(null));
     }
 
     @Test

--- a/src/test/java/seedu/billboard/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/billboard/logic/LogicManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.billboard.commons.core.Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX;
 import static seedu.billboard.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.billboard.logic.commands.CommandTestUtil.AMOUNT_DESC_DINNER;
+import static seedu.billboard.logic.commands.CommandTestUtil.DATE_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.NAME_DESC_DINNER;
 import static seedu.billboard.testutil.Assert.assertThrows;
@@ -79,7 +80,7 @@ public class LogicManagerTest {
 
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_DINNER + DESCRIPTION_DESC_DINNER
-                + AMOUNT_DESC_DINNER;
+                + AMOUNT_DESC_DINNER + DATE_DESC_DINNER;
         Expense expectedExpense = new ExpenseBuilder(DINNER).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addExpense(expectedExpense);

--- a/src/test/java/seedu/billboard/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/billboard/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.billboard.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_TAG;
@@ -31,6 +32,8 @@ public class CommandTestUtil {
     public static final String VALID_DESCRIPTION_TAXES = "paid income tax";
     public static final String VALID_AMOUNT_DINNER = "21.50";
     public static final String VALID_AMOUNT_TAXES = "320.50";
+    public static final String VALID_DATE_DINNER = "23/04/2018 1900";
+    public static final String VALID_DATE_TAXES = "11/05/2018";
     public static final String VALID_TAG_DINNER = "food";
     public static final String VALID_TAG_TAXES = "bills";
 
@@ -40,11 +43,14 @@ public class CommandTestUtil {
     public static final String DESCRIPTION_DESC_TAXES = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_TAXES;
     public static final String AMOUNT_DESC_DINNER = " " + PREFIX_AMOUNT + VALID_AMOUNT_DINNER;
     public static final String AMOUNT_DESC_TAXES = " " + PREFIX_AMOUNT + VALID_AMOUNT_TAXES;
+    public static final String DATE_DESC_DINNER = " " + PREFIX_DATE + VALID_DATE_DINNER;
+    public static final String DATE_DESC_TAXES = " " + PREFIX_DATE + VALID_DATE_TAXES;
     public static final String TAG_DESC_DINNER = " " + PREFIX_TAG + VALID_TAG_DINNER;
     public static final String TAG_DESC_TAXES = " " + PREFIX_TAG + VALID_TAG_TAXES;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "25.20abc"; // alphabet not allowed in amount
+    public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "23.12.19 1231";
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
@@ -56,10 +62,11 @@ public class CommandTestUtil {
     static {
         DESC_DINNER = new EditExpenseDescriptorBuilder().withName(VALID_NAME_DINNER)
                 .withDescription(VALID_DESCRIPTION_DINNER).withAmount(VALID_AMOUNT_DINNER)
-                .withTags(VALID_TAG_TAXES).build();
+                .withCreatedDateTime(VALID_DATE_DINNER).withTags(VALID_TAG_TAXES).build();
+
         DESC_TAXES = new EditExpenseDescriptorBuilder().withName(VALID_NAME_TAXES)
                 .withDescription(VALID_DESCRIPTION_TAXES).withAmount(VALID_AMOUNT_TAXES)
-                .withTags(VALID_TAG_DINNER, VALID_TAG_TAXES).build();
+                .withCreatedDateTime(VALID_DATE_TAXES).withTags(VALID_TAG_DINNER, VALID_TAG_TAXES).build();
     }
 
     /**

--- a/src/test/java/seedu/billboard/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/billboard/logic/parser/AddCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.billboard.logic.parser;
 import static seedu.billboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.billboard.logic.commands.CommandTestUtil.AMOUNT_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.AMOUNT_DESC_TAXES;
+import static seedu.billboard.logic.commands.CommandTestUtil.DATE_DESC_DINNER;
+import static seedu.billboard.logic.commands.CommandTestUtil.DATE_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
@@ -43,32 +45,36 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES
-                + AMOUNT_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
+                + AMOUNT_DESC_TAXES + DATE_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_DINNER + NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES
-                + AMOUNT_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
+                + AMOUNT_DESC_TAXES + DATE_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
 
         // multiple descriptions - last description accepted
         assertParseSuccess(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_DINNER + DESCRIPTION_DESC_TAXES
-                + AMOUNT_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
+                + AMOUNT_DESC_TAXES + DATE_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
 
         // multiple amounts - last amounts accepted
         assertParseSuccess(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES + AMOUNT_DESC_DINNER
-                + AMOUNT_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
+                + AMOUNT_DESC_TAXES + DATE_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
+
+        // multiple dates - last date accepted
+        assertParseSuccess(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES + AMOUNT_DESC_TAXES
+                + DATE_DESC_DINNER + DATE_DESC_TAXES + TAG_DESC_TAXES, new AddCommand(expectedExpense));
 
         // multiple tags - all accepted
         Expense expectedExpenseMultipleTags = new ExpenseBuilder(TAXES).withTags(VALID_TAG_TAXES, VALID_TAG_DINNER)
                 .build();
         assertParseSuccess(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES + AMOUNT_DESC_TAXES
-                + TAG_DESC_TAXES + TAG_DESC_DINNER, new AddCommand(expectedExpenseMultipleTags));
+                + TAG_DESC_TAXES + DATE_DESC_TAXES + TAG_DESC_DINNER, new AddCommand(expectedExpenseMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Expense expectedExpense = new ExpenseBuilder(DINNER).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_DINNER + DESCRIPTION_DESC_DINNER + AMOUNT_DESC_DINNER,
+        Expense expectedExpense = new ExpenseBuilder(DINNER).withTags().withDescription("").build();
+        assertParseSuccess(parser, NAME_DESC_DINNER + AMOUNT_DESC_DINNER + DATE_DESC_DINNER,
                 new AddCommand(expectedExpense));
     }
 

--- a/src/test/java/seedu/billboard/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/billboard/logic/parser/AddCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.billboard.logic.commands.CommandTestUtil.DATE_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
+import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.billboard.logic.commands.CommandTestUtil.NAME_DESC_DINNER;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import seedu.billboard.logic.commands.AddCommand;
 import seedu.billboard.logic.parser.exceptions.ParseException;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
 import seedu.billboard.model.tag.Tag;
@@ -104,6 +106,10 @@ public class AddCommandParserTest {
         // invalid amount
         assertParseFailure(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES + INVALID_AMOUNT_DESC
                 + TAG_DESC_TAXES + TAG_DESC_DINNER, Amount.MESSAGE_CONSTRAINTS);
+
+        // invalid date
+        assertParseFailure(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES + AMOUNT_DESC_TAXES
+                + INVALID_DATE_DESC + TAG_DESC_TAXES + TAG_DESC_DINNER, CreatedDateTime.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_TAXES + DESCRIPTION_DESC_TAXES + AMOUNT_DESC_TAXES

--- a/src/test/java/seedu/billboard/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/billboard/logic/parser/EditCommandParserTest.java
@@ -3,9 +3,12 @@ package seedu.billboard.logic.parser;
 import static seedu.billboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.billboard.logic.commands.CommandTestUtil.AMOUNT_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.AMOUNT_DESC_TAXES;
+import static seedu.billboard.logic.commands.CommandTestUtil.DATE_DESC_DINNER;
+import static seedu.billboard.logic.commands.CommandTestUtil.DATE_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.DESCRIPTION_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
+import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.billboard.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.billboard.logic.commands.CommandTestUtil.NAME_DESC_DINNER;
@@ -14,6 +17,8 @@ import static seedu.billboard.logic.commands.CommandTestUtil.TAG_DESC_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.TAG_DESC_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_AMOUNT_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_AMOUNT_TAXES;
+import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DATE_DINNER;
+import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DATE_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DESCRIPTION_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DESCRIPTION_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_NAME_DINNER;
@@ -33,6 +38,7 @@ import seedu.billboard.commons.core.index.Index;
 import seedu.billboard.logic.commands.EditCommand;
 import seedu.billboard.logic.commands.EditCommand.EditExpenseDescriptor;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Name;
 import seedu.billboard.model.tag.Tag;
 import seedu.billboard.testutil.EditExpenseDescriptorBuilder;
@@ -77,10 +83,15 @@ public class EditCommandParserTest {
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_AMOUNT_DESC, Amount.MESSAGE_CONSTRAINTS); // invalid amount
+        assertParseFailure(parser, "1" + INVALID_DATE_DESC, CreatedDateTime.MESSAGE_CONSTRAINTS); // invalid date
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid amount followed by valid name
         assertParseFailure(parser, "1" + INVALID_AMOUNT_DESC + NAME_DESC_DINNER, Amount.MESSAGE_CONSTRAINTS);
+
+        // invalid date followed by a valid amount
+        assertParseFailure(parser, "1" + INVALID_DATE_DESC + AMOUNT_DESC_TAXES,
+                CreatedDateTime.MESSAGE_CONSTRAINTS);
 
         // valid amount followed by invalid amount. The test case for invalid amount followed by valid amount
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
@@ -101,12 +112,13 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_EXPENSE;
 
-        String userInput = targetIndex.getOneBased() + NAME_DESC_DINNER + DESCRIPTION_DESC_TAXES + TAG_DESC_TAXES
-                + AMOUNT_DESC_DINNER + TAG_DESC_DINNER;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_DINNER + DESCRIPTION_DESC_TAXES + DATE_DESC_DINNER
+                + AMOUNT_DESC_DINNER + TAG_DESC_DINNER + TAG_DESC_TAXES;
 
         EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withName(VALID_NAME_DINNER)
                 .withDescription(VALID_DESCRIPTION_TAXES).withAmount(VALID_AMOUNT_DINNER)
-                .withTags(VALID_TAG_DINNER, VALID_TAG_TAXES).build();
+                .withCreatedDateTime(VALID_DATE_DINNER).withTags(VALID_TAG_DINNER, VALID_TAG_TAXES)
+                .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -144,6 +156,12 @@ public class EditCommandParserTest {
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
+        // date
+        userInput = targetIndex.getOneBased() + DATE_DESC_DINNER;
+        descriptor = new EditExpenseDescriptorBuilder().withCreatedDateTime(VALID_DATE_DINNER).build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_DINNER;
         descriptor = new EditExpenseDescriptorBuilder().withTags(VALID_TAG_DINNER).build();
@@ -155,11 +173,14 @@ public class EditCommandParserTest {
     public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_EXPENSE;
         String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_DINNER + AMOUNT_DESC_DINNER
-                + TAG_DESC_DINNER + DESCRIPTION_DESC_DINNER + AMOUNT_DESC_DINNER + TAG_DESC_DINNER
-                + DESCRIPTION_DESC_TAXES + AMOUNT_DESC_TAXES + TAG_DESC_TAXES;
+                + TAG_DESC_DINNER + DESCRIPTION_DESC_DINNER + AMOUNT_DESC_DINNER
+                + DATE_DESC_DINNER + DATE_DESC_TAXES + DESCRIPTION_DESC_TAXES
+                + AMOUNT_DESC_TAXES + TAG_DESC_TAXES + TAG_DESC_DINNER;
 
         EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withDescription(VALID_DESCRIPTION_TAXES)
-                .withAmount(VALID_AMOUNT_TAXES).withTags(VALID_TAG_TAXES, VALID_TAG_DINNER)
+                .withAmount(VALID_AMOUNT_TAXES)
+                .withCreatedDateTime(VALID_DATE_TAXES)
+                .withTags(VALID_TAG_TAXES, VALID_TAG_DINNER)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -179,12 +200,13 @@ public class EditCommandParserTest {
 
         // other valid values specified
         userInput = targetIndex.getOneBased() + AMOUNT_DESC_TAXES + INVALID_NAME_DESC + AMOUNT_DESC_TAXES
-                + NAME_DESC_TAXES;
+                + DATE_DESC_TAXES + NAME_DESC_TAXES;
         descriptor = new EditExpenseDescriptorBuilder()
                 .withAmount(VALID_AMOUNT_TAXES)
                 .withName(VALID_NAME_TAXES)
+                .withCreatedDateTime(VALID_DATE_TAXES)
                 .build();
-        System.out.println(userInput);
+
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/billboard/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/billboard/logic/parser/ParserUtilTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.billboard.logic.parser.exceptions.ParseException;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Name;
 import seedu.billboard.model.tag.Tag;
@@ -25,12 +26,14 @@ public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_AMOUNT = "test";
+    private static final String INVALID_DATE = "9/12/15/12 3529am";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_DESC = "eating at macs";
     private static final String VALID_AMOUNT = "2";
+    private static final String VALID_DATETIME = "05/03/2019 1234";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -69,7 +72,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseAmt_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseAmount((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseAmount(null));
     }
 
     @Test
@@ -79,7 +82,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseName_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseName(null));
     }
 
     @Test
@@ -122,7 +125,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseDesc_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription(null));
     }
 
     @Test
@@ -216,4 +219,28 @@ public class ParserUtilTest {
 
         assertEquals(expectedTagNamesList, actualTagNamesList);
     }
+
+    @Test
+    public void parseCreatedDateTime_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseCreatedDateTime(null));
+    }
+
+    @Test
+    public void parseCreatedDateTime_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCreatedDateTime(INVALID_DATE));
+    }
+
+    @Test
+    public void parseCreatedDateTime_validValueWithoutWhitespace_returnsCreatedDateTime() throws Exception {
+        CreatedDateTime expectedCreatedDateTime = new CreatedDateTime(VALID_DATETIME);
+        assertEquals(expectedCreatedDateTime, ParserUtil.parseCreatedDateTime(VALID_DATETIME));
+    }
+
+    @Test
+    public void parseCreatedDateTime_validValueWithWhitespace_returnsTrimmedCreatedDateTime() throws Exception {
+        String dateTimeWithWhitespace = WHITESPACE + VALID_DATETIME + WHITESPACE;
+        CreatedDateTime expected = new CreatedDateTime(VALID_DATETIME);
+        assertEquals(expected, ParserUtil.parseCreatedDateTime(dateTimeWithWhitespace));
+    }
+
 }

--- a/src/test/java/seedu/billboard/model/expense/CreatedDateTimeTest.java
+++ b/src/test/java/seedu/billboard/model/expense/CreatedDateTimeTest.java
@@ -1,0 +1,41 @@
+package seedu.billboard.model.expense;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.billboard.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class CreatedDateTimeTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new CreatedDateTime((String) null));
+    }
+
+    @Test
+    public void constructor_invalidDate_throwsIllegalArgumentException() {
+        String invalidDate = "june";
+        assertThrows(IllegalArgumentException.class, () -> new CreatedDateTime(invalidDate));
+    }
+
+    @Test
+    public void isValidDate() {
+        // null date
+        assertThrows(NullPointerException.class, () -> CreatedDateTime.isValidDate(null));
+
+        // invalid date
+        assertFalse(CreatedDateTime.isValidDate("")); // empty string
+        assertFalse(CreatedDateTime.isValidDate(" ")); // spaces only
+        assertFalse(CreatedDateTime.isValidDate("2359 23/12/2019")); // wrong format
+        assertFalse(CreatedDateTime.isValidDate("32/1/2019 1234")); // correct format, non existent date
+        assertFalse(CreatedDateTime.isValidDate("31/1/2019 2401")); // correct format, non existent time
+        assertFalse(CreatedDateTime.isValidDate("07/01/2019 12:34")); // slightly wrong format
+
+        // valid name
+        assertTrue(CreatedDateTime.isValidDate("23/12/2019 1234")); // normal date with time
+        assertTrue(CreatedDateTime.isValidDate("23/12/2019")); // normal date no time
+        assertTrue(CreatedDateTime.isValidDate("1/1/2019")); // date without leading zeros
+        assertTrue(CreatedDateTime.isValidDate("01/01/2019")); // date with leading zeroes
+    }
+}

--- a/src/test/java/seedu/billboard/model/expense/CreatedDateTimeTest.java
+++ b/src/test/java/seedu/billboard/model/expense/CreatedDateTimeTest.java
@@ -32,7 +32,7 @@ public class CreatedDateTimeTest {
         assertFalse(CreatedDateTime.isValidDate("31/1/2019 2401")); // correct format, non existent time
         assertFalse(CreatedDateTime.isValidDate("07/01/2019 12:34")); // slightly wrong format
 
-        // valid name
+        // valid date
         assertTrue(CreatedDateTime.isValidDate("23/12/2019 1234")); // normal date with time
         assertTrue(CreatedDateTime.isValidDate("23/12/2019")); // normal date no time
         assertTrue(CreatedDateTime.isValidDate("1/1/2019")); // date without leading zeros

--- a/src/test/java/seedu/billboard/model/expense/ExpenseTest.java
+++ b/src/test/java/seedu/billboard/model/expense/ExpenseTest.java
@@ -3,6 +3,7 @@ package seedu.billboard.model.expense;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_AMOUNT_TAXES;
+import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DATE_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DESCRIPTION_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_NAME_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_TAG_DINNER;
@@ -50,6 +51,10 @@ public class ExpenseTest {
 
         // different amount -> returns false
         editedBills = new ExpenseBuilder(BILLS).withAmount(VALID_AMOUNT_TAXES).build();
+        assertNotEquals(BILLS, editedBills);
+
+        // different date -> returns false
+        editedBills = new ExpenseBuilder(BILLS).withCreatedDateTime(VALID_DATE_TAXES).build();
         assertNotEquals(BILLS, editedBills);
 
         // different tags -> returns false

--- a/src/test/java/seedu/billboard/model/statistics/ExpenseTimelineTest.java
+++ b/src/test/java/seedu/billboard/model/statistics/ExpenseTimelineTest.java
@@ -13,6 +13,7 @@ import java.util.stream.IntStream;
 
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.jupiter.api.Test;
+
 import seedu.billboard.commons.core.date.DateInterval;
 import seedu.billboard.commons.core.date.DateRange;
 import seedu.billboard.commons.exceptions.IllegalValueException;

--- a/src/test/java/seedu/billboard/model/statistics/ExpenseTimelineTest.java
+++ b/src/test/java/seedu/billboard/model/statistics/ExpenseTimelineTest.java
@@ -1,0 +1,73 @@
+package seedu.billboard.model.statistics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static seedu.billboard.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.jupiter.api.Test;
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.commons.core.date.DateRange;
+import seedu.billboard.commons.exceptions.IllegalValueException;
+import seedu.billboard.model.expense.Amount;
+
+
+public class ExpenseTimelineTest {
+
+    @Test
+    public void constructor_numberOfIntervalsAndSizeOfAggregateExpenseListMismatch_throwsException()
+            throws IllegalValueException {
+        DateRange dateRange = new DateRange(LocalDate.of(2016, 6, 12),
+                LocalDate.of(2017, 6, 21));
+        DateInterval interval = DateInterval.MONTH;
+
+        List<Amount> amounts = IntStream.range(0, 11)
+                .mapToObj(i -> new Amount(i + ""))
+                .collect(Collectors.toList());
+
+        assertThrows(IllegalValueException.class, () -> new ExpenseTimeline(dateRange, interval, amounts));
+    }
+
+    @Test
+    public void getTimeline_oneInterval_expectedMap() throws IllegalValueException {
+        DateRange dateRange = new DateRange(LocalDate.of(2019, 1, 1),
+                LocalDate.of(2019, 1, 6));
+
+        DateInterval interval = DateInterval.WEEK;
+        List<Amount> amounts = Collections.singletonList(new Amount("1.50"));
+
+        Map<DateRange, Amount> actual = new ExpenseTimeline(dateRange, interval, amounts).getTimeline();
+
+        assertThat(actual,
+                IsMapContaining.hasEntry(dateRange.partitionByInterval(interval).get(0), new Amount("1.50")));
+    }
+
+    @Test
+    public void getTimeline_manyIntervals_expectedMap() throws IllegalValueException {
+        DateRange dateRange = new DateRange(LocalDate.of(2000, 1, 4),
+                LocalDate.of(2000, 12, 2));
+
+        DateInterval interval = DateInterval.MONTH;
+        List<Amount> amounts = IntStream.rangeClosed(1, 12)
+                .mapToObj(i -> new Amount(i + ".20"))
+                .collect(Collectors.toList());
+
+        Map<DateRange, Amount> actual = new ExpenseTimeline(dateRange, interval, amounts).getTimeline();
+
+        for (int i = 1; i <= 12; i++) {
+            DateRange range = new DateRange(LocalDate.of(2000, i, 1),
+                    LocalDate.of(2000, i, 1).with(TemporalAdjusters.lastDayOfMonth()));
+            Amount amount = new Amount(i + ".20");
+
+            assertThat(actual, IsMapContaining.hasEntry(range, amount));
+        }
+
+    }
+}

--- a/src/test/java/seedu/billboard/model/statistics/ExpenseTimelineTest.java
+++ b/src/test/java/seedu/billboard/model/statistics/ExpenseTimelineTest.java
@@ -25,13 +25,14 @@ public class ExpenseTimelineTest {
     @Test
     public void constructor_numberOfIntervalsAndSizeOfAggregateExpenseListMismatch_throwsException()
             throws IllegalValueException {
+
         DateRange dateRange = new DateRange(LocalDate.of(2016, 6, 12),
                 LocalDate.of(2017, 6, 21));
-        DateInterval interval = DateInterval.MONTH;
+        DateInterval interval = DateInterval.MONTH; // 12 months
 
         List<Amount> amounts = IntStream.range(0, 11)
                 .mapToObj(i -> new Amount(i + ""))
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()); // 11 aggregate expenses
 
         assertThrows(IllegalValueException.class, () -> new ExpenseTimeline(dateRange, interval, amounts));
     }

--- a/src/test/java/seedu/billboard/model/statistics/StatisticsGeneratorTest.java
+++ b/src/test/java/seedu/billboard/model/statistics/StatisticsGeneratorTest.java
@@ -1,0 +1,77 @@
+package seedu.billboard.model.statistics;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.billboard.testutil.Assert.assertThrows;
+import static seedu.billboard.testutil.TypicalExpenses.BILLS;
+import static seedu.billboard.testutil.TypicalExpenses.GROCERIES;
+import static seedu.billboard.testutil.TypicalExpenses.MOVIE;
+import static seedu.billboard.testutil.TypicalExpenses.getTypicalExpenses;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.jupiter.api.Test;
+
+import seedu.billboard.commons.core.date.DateInterval;
+import seedu.billboard.commons.core.date.DateRange;
+import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.Expense;
+import seedu.billboard.testutil.TypicalExpenses;
+
+
+public class StatisticsGeneratorTest {
+    private final StatisticsGenerator statsGenerator = new StatisticsGenerator();
+
+    @Test
+    public void generateExpenseTimeline_nullArguments_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> statsGenerator.generateExpenseTimeline(null));
+        assertThrows(NullPointerException.class, () ->
+                statsGenerator.generateExpenseTimeline(null, null));
+        assertThrows(NullPointerException.class, () ->
+                statsGenerator.generateExpenseTimeline(Collections.singletonList(TypicalExpenses.BILLS), null));
+    }
+
+    @Test
+    void generateExpenseTimeline_emptyList_returnsEmptyExpenseTimeline() {
+        ExpenseTimeline timeline = statsGenerator.generateExpenseTimeline(new ArrayList<>());
+
+        assertThat(timeline, is(instanceOf(EmptyExpenseTimeline.class)));
+    }
+
+    // Based of expenses list from {@code TypicalExpenses#getTypicalExpenses}.
+    @Test
+    void generateExpenseTimeline_nonEmptyList_returnsCorrectExpenseTimeline() {
+        DateInterval interval = DateInterval.MONTH;
+        ExpenseTimeline timeline = statsGenerator.generateExpenseTimeline(getTypicalExpenses(), interval);
+
+        assertThat(timeline, is(instanceOf(FilledExpenseTimeline.class))); // check type
+
+        assertEquals(new DateRange(BILLS.getCreated().dateTime.toLocalDate(),
+                        GROCERIES.getCreated().dateTime.toLocalDate()),
+                timeline.getDateRange()); // check range
+
+        assertEquals(DateInterval.MONTH, timeline.getDateInterval()); // check interval
+
+        // check map
+        Map<DateRange, Amount> actualTimeline = timeline.getTimeline();
+        DateRange billsDateRange = getAdjustedDateRangeWithIntervalFromExpense(BILLS, interval);
+        assertThat(actualTimeline, IsMapContaining.hasEntry(billsDateRange, new Amount("350.25")));
+
+        DateRange foodAndMovieDateRange = getAdjustedDateRangeWithIntervalFromExpense(MOVIE, interval);
+        assertThat(actualTimeline, IsMapContaining.hasEntry(foodAndMovieDateRange, new Amount("14.20")));
+
+        DateRange groceriesDateRange = getAdjustedDateRangeWithIntervalFromExpense(GROCERIES, interval);
+        assertThat(actualTimeline, IsMapContaining.hasEntry(groceriesDateRange, new Amount("23.50")));
+    }
+
+    private DateRange getAdjustedDateRangeWithIntervalFromExpense(Expense expense, DateInterval interval) {
+        LocalDate start = expense.getCreated().dateTime.toLocalDate().with(interval.getAdjuster());
+        return DateRange.overPeriod(start, interval.getPeriod());
+    }
+}

--- a/src/test/java/seedu/billboard/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/seedu/billboard/storage/JsonAdaptedExpenseTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.billboard.commons.exceptions.IllegalValueException;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Name;
 
@@ -20,11 +21,13 @@ import seedu.billboard.model.expense.Name;
 public class JsonAdaptedExpenseTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_AMOUNT = "2af2";
+    private static final String INVALID_DATE = "^ba#Fj0";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = FOOD.getName().toString();
     private static final String VALID_DESCRIPTION = FOOD.getDescription().toString();
     private static final String VALID_AMOUNT = FOOD.getAmount().toString();
+    private static final String VALID_DATE = FOOD.getCreated().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = FOOD.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -38,14 +41,15 @@ public class JsonAdaptedExpenseTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
-                new JsonAdaptedExpense(INVALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, VALID_TAGS);
+                new JsonAdaptedExpense(INVALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, VALID_DATE, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedExpense expense = new JsonAdaptedExpense(null, VALID_DESCRIPTION, VALID_AMOUNT, VALID_TAGS);
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(
+                null, VALID_DESCRIPTION, VALID_AMOUNT, VALID_DATE, VALID_TAGS);
 
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
@@ -53,7 +57,7 @@ public class JsonAdaptedExpenseTest {
 
     @Test
     public void toModelType_nullDescription_throwsIllegalValueException() {
-        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_NAME, null, VALID_AMOUNT, VALID_TAGS);
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_NAME, null, VALID_AMOUNT, VALID_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
 
@@ -62,15 +66,33 @@ public class JsonAdaptedExpenseTest {
     @Test
     public void toModelType_invalidAmount_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
-                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, INVALID_AMOUNT, VALID_TAGS);
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, INVALID_AMOUNT, VALID_DATE, VALID_TAGS);
         String expectedMessage = Amount.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
 
     @Test
     public void toModelType_nullAmount_throwsIllegalValueException() {
-        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, null, VALID_TAGS);
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, null, VALID_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+
+    }
+
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, INVALID_DATE, VALID_TAGS);
+        String expectedMessage = CreatedDateTime.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, null, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, CreatedDateTime.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
 
     }
@@ -80,7 +102,7 @@ public class JsonAdaptedExpenseTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedExpense expense =
-                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, invalidTags);
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, VALID_DATE, invalidTags);
         assertThrows(IllegalValueException.class, expense::toModelType);
     }
 

--- a/src/test/java/seedu/billboard/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/seedu/billboard/storage/JsonAdaptedExpenseTest.java
@@ -77,8 +77,8 @@ public class JsonAdaptedExpenseTest {
 
     @Test
     public void toModelType_nullAmount_throwsIllegalValueException() {
-        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, null, VALID_DATE,
-                VALID_TAGS, VALID_ARCHIVE);
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, null,
+                VALID_DATE, VALID_TAGS, VALID_ARCHIVE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
 
@@ -87,7 +87,8 @@ public class JsonAdaptedExpenseTest {
     @Test
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
-                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, INVALID_DATE, VALID_TAGS);
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT,
+                        INVALID_DATE, VALID_TAGS, VALID_ARCHIVE);
         String expectedMessage = CreatedDateTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
@@ -95,7 +96,8 @@ public class JsonAdaptedExpenseTest {
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
-                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT, null, VALID_TAGS);
+                new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT,
+                        null, VALID_TAGS, VALID_ARCHIVE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, CreatedDateTime.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
 
@@ -108,6 +110,7 @@ public class JsonAdaptedExpenseTest {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(VALID_NAME, VALID_DESCRIPTION, VALID_AMOUNT,
                         VALID_DATE, invalidTags, VALID_ARCHIVE);
+
         assertThrows(IllegalValueException.class, expense::toModelType);
     }
 

--- a/src/test/java/seedu/billboard/testutil/EditExpenseDescriptorBuilder.java
+++ b/src/test/java/seedu/billboard/testutil/EditExpenseDescriptorBuilder.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import seedu.billboard.logic.commands.EditCommand;
 import seedu.billboard.logic.commands.EditCommand.EditExpenseDescriptor;
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
@@ -35,6 +36,7 @@ public class EditExpenseDescriptorBuilder {
         descriptor.setName(expense.getName());
         descriptor.setDescription(expense.getDescription());
         descriptor.setAmount(expense.getAmount());
+        descriptor.setCreated(expense.getCreated());
         descriptor.setTags(expense.getTags());
     }
 
@@ -61,6 +63,15 @@ public class EditExpenseDescriptorBuilder {
         descriptor.setAmount(new Amount(amount));
         return this;
     }
+
+    /**
+     * Sets the {@code Description} of the {@code EditExpenseDescriptor} that we are building.
+     */
+    public EditExpenseDescriptorBuilder withCreatedDateTime(String dateTime) {
+        descriptor.setCreated(new CreatedDateTime(dateTime));
+        return this;
+    }
+
 
     /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditExpenseDescriptor}

--- a/src/test/java/seedu/billboard/testutil/ExpenseBuilder.java
+++ b/src/test/java/seedu/billboard/testutil/ExpenseBuilder.java
@@ -19,7 +19,7 @@ public class ExpenseBuilder {
     public static final String DEFAULT_NAME = "pay school fees";
     public static final String DEFAULT_DESCRIPTION = "this is a description.";
     public static final String DEFAULT_AMOUNT = "4.20";
-    public static final String DEFAULT_DATE = "1/1/2019";
+    public static final String DEFAULT_DATE = "1/1/2019 1234";
 
     private Name name;
     private Description description;

--- a/src/test/java/seedu/billboard/testutil/ExpenseBuilder.java
+++ b/src/test/java/seedu/billboard/testutil/ExpenseBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.billboard.model.expense.Amount;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Description;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.expense.Name;
@@ -18,16 +19,19 @@ public class ExpenseBuilder {
     public static final String DEFAULT_NAME = "pay school fees";
     public static final String DEFAULT_DESCRIPTION = "this is a description.";
     public static final String DEFAULT_AMOUNT = "4.20";
+    public static final String DEFAULT_DATE = "1/1/2019";
 
     private Name name;
     private Description description;
     private Amount amount;
+    private CreatedDateTime created;
     private Set<Tag> tags;
 
     public ExpenseBuilder() {
         name = new Name(DEFAULT_NAME);
         description = new Description(DEFAULT_DESCRIPTION);
         amount = new Amount(DEFAULT_AMOUNT);
+        created = new CreatedDateTime(DEFAULT_DATE);
         tags = new HashSet<>();
     }
 
@@ -38,6 +42,7 @@ public class ExpenseBuilder {
         name = expenseToCopy.getName();
         description = expenseToCopy.getDescription();
         amount = expenseToCopy.getAmount();
+        created = expenseToCopy.getCreated();
         tags = new HashSet<>(expenseToCopy.getTags());
     }
 
@@ -86,8 +91,16 @@ public class ExpenseBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code CreatedDateTime} of the {@code Expense} that we are building.
+     */
+    public ExpenseBuilder withCreatedDateTime(String createdDateTime) {
+        this.created = new CreatedDateTime(createdDateTime);
+        return this;
+    }
+
     public Expense build() {
-        return new Expense(name, description, amount, tags);
+        return new Expense(name, description, amount, created, tags);
     }
 
 }

--- a/src/test/java/seedu/billboard/testutil/ExpenseUtil.java
+++ b/src/test/java/seedu/billboard/testutil/ExpenseUtil.java
@@ -1,14 +1,17 @@
 package seedu.billboard.testutil;
 
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.billboard.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
 import seedu.billboard.logic.commands.AddCommand;
 import seedu.billboard.logic.commands.EditCommand.EditExpenseDescriptor;
+import seedu.billboard.model.expense.CreatedDateTime;
 import seedu.billboard.model.expense.Expense;
 import seedu.billboard.model.tag.Tag;
 
@@ -30,8 +33,12 @@ public class ExpenseUtil {
     public static String getExpenseDetails(Expense expense) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME).append(expense.getName().name).append(" ")
-            .append(PREFIX_DESCRIPTION).append(expense.getDescription().description).append(" ")
-            .append(PREFIX_AMOUNT).append(expense.getAmount().amount).append(" ");
+                .append(PREFIX_DESCRIPTION).append(expense.getDescription().description).append(" ")
+                .append(PREFIX_DATE)
+                .append(DateTimeFormatter.ofPattern(CreatedDateTime.ACCEPTABLE_PATTERNS.get(0))
+                        .format(expense.getCreated().dateTime))
+                .append(" ")
+                .append(PREFIX_AMOUNT).append(expense.getAmount().amount).append(" ");
 
         expense.getTags().forEach(
             s -> sb.append(PREFIX_TAG).append(s.tagName).append(" ")

--- a/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
+++ b/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
@@ -63,21 +63,25 @@ public class TypicalExpenses {
     public static final Expense IPHONE11 = new ExpenseBuilder().withName("iphone 11")
             .withDescription("iphone 11 pro 132312321GB memory")
             .withAmount("10000")
+            .withCreatedDateTime("1/1/2019 0001")
             .withArchiveName("luxury")
             .build();
     public static final Expense GUCCI_SLIDES = new ExpenseBuilder().withName("Gucci slides")
             .withDescription("bought them cos I got sick of my slippers")
             .withAmount("299.99")
+            .withCreatedDateTime("1/1/2019 0002")
             .withArchiveName("luxury")
             .build();
     public static final Expense KPOP_LIGHT_STICK = new ExpenseBuilder().withName("Kpop lightstick")
             .withDescription("bought at kpoop concert")
             .withAmount("70")
+            .withCreatedDateTime("1/1/2019 0003")
             .withArchiveName("hobbies")
             .build();
     public static final Expense FOOTBALL = new ExpenseBuilder().withName("Nike football")
             .withDescription("To play with")
             .withAmount("39.99")
+            .withCreatedDateTime("1/1/2019 0004")
             .withArchiveName("hobbies")
             .build();
 

--- a/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
+++ b/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
@@ -2,6 +2,8 @@ package seedu.billboard.testutil;
 
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_AMOUNT_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_AMOUNT_TAXES;
+import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DATE_DINNER;
+import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DATE_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DESCRIPTION_DINNER;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_DESCRIPTION_TAXES;
 import static seedu.billboard.logic.commands.CommandTestUtil.VALID_NAME_DINNER;
@@ -59,11 +61,14 @@ public class TypicalExpenses {
     public static final Expense DINNER = new ExpenseBuilder().withName(VALID_NAME_DINNER)
             .withDescription(VALID_DESCRIPTION_DINNER)
             .withAmount(VALID_AMOUNT_DINNER)
-            .withTags(VALID_TAG_TAXES).build();
+            .withCreatedDateTime(VALID_DATE_DINNER)
+            .withTags(VALID_TAG_TAXES)
+            .build();
 
     public static final Expense TAXES = new ExpenseBuilder().withName(VALID_NAME_TAXES)
             .withDescription(VALID_DESCRIPTION_TAXES)
             .withAmount(VALID_AMOUNT_TAXES)
+            .withCreatedDateTime(VALID_DATE_TAXES)
             .withTags(VALID_TAG_DINNER, VALID_TAG_TAXES)
             .build();
 

--- a/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
+++ b/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
@@ -36,7 +36,7 @@ public class TypicalExpenses {
     public static final Expense GROCERIES = new ExpenseBuilder().withName("groceries")
             .withDescription("bought from fairprice")
             .withAmount("23.50")
-            .withCreatedDateTime("12/01/2019 1200")
+            .withCreatedDateTime("12/02/2019 1200")
             .build();
     public static final Expense MOVIE = new ExpenseBuilder().withName("movie tickets")
             .withDescription("tickets to joker")

--- a/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
+++ b/src/test/java/seedu/billboard/testutil/TypicalExpenses.java
@@ -24,28 +24,35 @@ public class TypicalExpenses {
     public static final Expense BILLS = new ExpenseBuilder().withName("monthly bills")
             .withDescription("pay phone company")
             .withAmount("350.25")
+            .withCreatedDateTime("09/9/2018 2152")
             .withTags("bills").build();
     public static final Expense FOOD = new ExpenseBuilder().withName("monday breakfast food")
             .withDescription("toast with frens")
             .withAmount("4.20")
+            .withCreatedDateTime("12/01/2019")
             .withTags("monday", "friends").build();
     public static final Expense GROCERIES = new ExpenseBuilder().withName("groceries")
             .withDescription("bought from fairprice")
             .withAmount("23.50")
+            .withCreatedDateTime("12/01/2019 1200")
             .build();
     public static final Expense MOVIE = new ExpenseBuilder().withName("movie tickets")
             .withDescription("tickets to joker")
-            .withAmount("10.00").withTags("leisure").build();
+            .withAmount("10.00")
+            .withCreatedDateTime("01/01/2019 0530")
+            .withTags("leisure").build();
 
 
     // Manually added
     public static final Expense CLOTHES = new ExpenseBuilder().withName("clothes")
             .withDescription("bought new yeezys")
             .withAmount("1000")
+            .withCreatedDateTime("1/1/2019 0000")
             .build();
     public static final Expense NEW_LAPTOP = new ExpenseBuilder().withName("new laptop")
             .withDescription("new macbook pro")
             .withAmount("2999.99")
+            .withCreatedDateTime("31/12/2019 2359")
             .build();
 
     // Manually added - Expense's details found in {@code CommandTestUtil}


### PR DESCRIPTION
# Added:
* `DateRange` - Represents the the range of dates between a give start and end date, inclusive.
* `DateInterval` - Enum representing the various date intervals that can be used to divide the timeline. Has helper attributes to manipulate dates to human-useful date intervals.
* `ExpenseTimeline` - Interface encapsulating operations to extract timeline data out of a list of expenses
* `FilledExpenseTimeline` and `EmptyExpenseTimeline` - Concrete classes implementing above interface.
* `Statistics` - Interface encapsulating operations to generate statistics from various sources. Can be extensible to further supported statistics in the future.
* `StatisticsGenerator` - Concrete class implementing above interface.
* Tests for most of the above.

# Todo
* Update Ui to make use of `ExpenseTimeline`.
* Orchestrate the linking of filtered view of expenses to the statistics shown.