### PR TITLE
Fixed undo and redo commands to copy the undone/redone model instead

### DIFF
--- a/src/main/java/seedu/billboard/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/billboard/logic/commands/RedoCommand.java
@@ -28,8 +28,7 @@ public class RedoCommand extends Command {
 
         String redoCmd = VersionedBillboard.getRedoCmd();
         Model undoModel = VersionedBillboard.getRedoModel();
-        model.setModel(undoModel);
-        CommandResult cmdResult = new CommandResult(String.format(MESSAGE_REDO_SUCCESS, redoCmd));
-        return cmdResult;
+        model.setModel(undoModel.getClone());
+        return new CommandResult(String.format(MESSAGE_REDO_SUCCESS, redoCmd));
     }
 }

--- a/src/main/java/seedu/billboard/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/billboard/logic/commands/UndoCommand.java
@@ -28,7 +28,7 @@ public class UndoCommand extends Command {
 
         Model undoModel = VersionedBillboard.getUndoModel();
         String undoCmd = VersionedBillboard.getUndoCmd();
-        model.setModel(undoModel);
+        model.setModel(undoModel.getClone());
         return new CommandResult(String.format(MESSAGE_UNDO_SUCCESS, undoCmd));
     }
 }

--- a/src/main/java/seedu/billboard/model/ModelManager.java
+++ b/src/main/java/seedu/billboard/model/ModelManager.java
@@ -347,7 +347,7 @@ public class ModelManager implements Model {
     public String toString() {
         return "Billboard: " + billboard.toString()
                 + "\nArchives: " + archives.toString()
-                + "\nFilteredExpenses: " + filteredExpense.toString()
-                + "\nFilteredArchives: " + filteredArchives.toString();
+                + "\nFiltered Expenses: " + filteredExpense.toString()
+                + "\nFiltered Archives: " + filteredArchives.toString();
     }
 }

--- a/src/main/java/seedu/billboard/model/ModelManager.java
+++ b/src/main/java/seedu/billboard/model/ModelManager.java
@@ -342,4 +342,12 @@ public class ModelManager implements Model {
                 && filteredExpense.equals(other.filteredExpense)
                 && filteredArchives.equals(other.filteredArchives);
     }
+
+    @Override
+    public String toString() {
+        return "Billboard: " + billboard.toString()
+                + "\nArchives: " + archives.toString()
+                + "\nFilteredExpenses: " + filteredExpense.toString()
+                + "\nFilteredArchives: " + filteredArchives.toString();
+    }
 }

--- a/src/main/java/seedu/billboard/model/expense/ExpenseList.java
+++ b/src/main/java/seedu/billboard/model/expense/ExpenseList.java
@@ -132,7 +132,7 @@ public class ExpenseList implements Iterable<Expense> {
     public ExpenseList getClone() {
         ExpenseList clonedList = new ExpenseList();
         for (Expense e : this.internalList) {
-            Expense clonedExpense = e.getClone(); // get a deeep clone of each expense
+            Expense clonedExpense = e.getClone(); // get a deep clone of each expense
             clonedList.add(clonedExpense);
         }
         return clonedList;


### PR DESCRIPTION
Closes #193 

The old implentation of undo/redo set the current model to the model saved in the versioned billboard without copying. As a result, when doing any command that alters the model, the history saved in the versioned billboard can be altered as well, causing odd results.

Fixed the implementation to copy the undoModel/redoModel instead of simply setting the current model.